### PR TITLE
Refactor version.go and bugfix

### DIFF
--- a/version.go
+++ b/version.go
@@ -24,10 +24,6 @@ import (
 	"strings"
 )
 
-const (
-	DOT = "."
-)
-
 var currentGaugeVersion = &version{0, 0, 7}
 
 type version struct {
@@ -37,24 +33,28 @@ type version struct {
 }
 
 func parseVersion(versionText string) (*version, error) {
-	splits := strings.Split(versionText, DOT)
+	splits := strings.Split(versionText, ".")
 	if len(splits) != 3 {
-		return nil, errors.New("Incorrect number of '.' characters in Version. Version should be of the form 1.5.7")
+		return nil, errors.New("Incorrect version format. Version should be in the form 1.5.7")
 	}
 	major, err := strconv.Atoi(splits[0])
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Error parsing major version number %s to integer. %s", splits[0], err.Error()))
+		return nil, versionError("major", splits[0], err)
 	}
 	minor, err := strconv.Atoi(splits[1])
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Error parsing minor version number %s to integer. %s", splits[0], err.Error()))
+		return nil, versionError("minor", splits[1], err)
 	}
 	patch, err := strconv.Atoi(splits[2])
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Error parsing patch version number %s to integer. %s", splits[0], err.Error()))
+		return nil, versionError("patch", splits[2], err)
 	}
 
 	return &version{major, minor, patch}, nil
+}
+
+func versionError(level, text string, err error) error {
+	return errors.New(fmt.Sprintf("Error parsing %s version %s to integer. %s", level, text, err.Error()))
 }
 
 func (version *version) isBetween(lower *version, greater *version) bool {

--- a/version_test.go
+++ b/version_test.go
@@ -31,26 +31,21 @@ func (s *MySuite) TestParsingVersion(c *C) {
 
 func (s *MySuite) TestParsingErrorForIncorrectNumberOfDotCharacters(c *C) {
 	_, err := parseVersion("1.5.9.9")
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "Incorrect number of '.' characters in Version. Version should be of the form 1.5.7")
+	c.Assert(err, ErrorMatches, "Incorrect version format. Version should be in the form 1.5.7")
 
 	_, err = parseVersion("0.")
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "Incorrect number of '.' characters in Version. Version should be of the form 1.5.7")
+	c.Assert(err, ErrorMatches, "Incorrect version format. Version should be in the form 1.5.7")
 }
 
 func (s *MySuite) TestParsingErrorForNonIntegerVersion(c *C) {
 	_, err := parseVersion("a.9.0")
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "Error parsing major version number a to integer. strconv.ParseInt: parsing \"a\": invalid syntax")
+	c.Assert(err, ErrorMatches, `Error parsing major version a to integer. strconv.ParseInt: parsing "a": invalid syntax`)
 
 	_, err = parseVersion("0.ffhj.78")
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "Error parsing minor version number 0 to integer. strconv.ParseInt: parsing \"ffhj\": invalid syntax")
+	c.Assert(err, ErrorMatches, `Error parsing minor version ffhj to integer. strconv.ParseInt: parsing "ffhj": invalid syntax`)
 
 	_, err = parseVersion("8.9.opl")
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "Error parsing patch version number 8 to integer. strconv.ParseInt: parsing \"opl\": invalid syntax")
+	c.Assert(err, ErrorMatches, `Error parsing patch version opl to integer. strconv.ParseInt: parsing "opl": invalid syntax`)
 }
 
 func (s *MySuite) TestVersionComparisonGreaterLesser(c *C) {


### PR DESCRIPTION
Create a `versionError` function to reduce verbosity

Prior to this fix version was reporting incorrect errors due to wrong indexes.

Tests now use more idiomatic matchers