### PR TITLE
Don't run default specs if --failed is run with no previous failures

### DIFF
--- a/gauge.go
+++ b/gauge.go
@@ -84,9 +84,13 @@ func main() {
 	flag.Parse()
 	util.SetWorkingDir(*workingDir)
 	initPackageFlags()
-	rerun.SetFlags()
+	err := rerun.Initialize()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(0)
+	}
 	validGaugeProject := true
-	err := config.SetProjectRoot(flag.Args())
+	err = config.SetProjectRoot(flag.Args())
 	if err != nil {
 		validGaugeProject = false
 	}


### PR DESCRIPTION
- Wrap `runner.SetFlags()` in `runner.Initialize()`.
- `runner.Initialize()` returns returns error if `--failed` flag is set, but no previous failures are found
- `main()` calls `runner.Initialize()` and exits if it returns an error.

This addresses #418. Putting it up for code review suggestions.