### PR TITLE
Adding --debug-api flag

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -131,6 +131,10 @@
 		{
 			"ImportPath": "gopkg.in/check.v1",
 			"Rev": "20d25e2804050c1cd24a7eea1e7a6447dd0e74ec"
+		},
+		{
+			"ImportPath": "github.com/shirou/gopsutil",
+			"Rev": "98d5de7ce9acd16b430be82ef4448ca578537a4a"
 		}
 	]
 }

--- a/build/make.go
+++ b/build/make.go
@@ -215,7 +215,7 @@ func main() {
 	flag.Parse()
 	if *nightly {
 		buildMetadata = fmt.Sprintf("nightly-%s", time.Now().Format(nightlyDatelayout))
-	} 
+	}
 	// disabled this temporarily.
 	// dependency on external package breaks vendoring, since make.go is in a different package, i.e. not in gauge
 	// os.Stdin.Stat is the way to go, but it doesnt work on windows. Fix tentatively in go1.9

--- a/debug/api.go
+++ b/debug/api.go
@@ -1,0 +1,43 @@
+package debug
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/getgauge/common"
+	"github.com/getgauge/gauge/conn"
+	m "github.com/getgauge/gauge/gauge_messages"
+	"github.com/golang/protobuf/proto"
+)
+
+type api struct {
+	connection net.Conn
+}
+
+func newAPI(host string, port string) (*api, error) {
+	c, err := net.Dial("tcp", fmt.Sprintf("%s:%s", host, port))
+	return &api{connection: c}, err
+}
+
+func (a *api) getResponse(message *m.APIMessage) (*m.APIMessage, error) {
+	messageId := common.GetUniqueID()
+	message.MessageId = messageId
+
+	data, err := proto.Marshal(message)
+	if err != nil {
+		return nil, err
+	}
+	responseBytes, err := conn.WriteDataAndGetResponse(a.connection, data)
+	if err != nil {
+		return nil, err
+	}
+	responseMessage := &m.APIMessage{}
+	if err := proto.Unmarshal(responseBytes, responseMessage); err != nil {
+		return nil, err
+	}
+	return responseMessage, err
+}
+
+func (a *api) close() {
+	a.connection.Close()
+}

--- a/debug/handler.go
+++ b/debug/handler.go
@@ -1,0 +1,129 @@
+package debug
+
+import (
+	"net/http"
+
+	"encoding/json"
+
+	"strconv"
+
+	"strings"
+
+	m "github.com/getgauge/gauge/gauge_messages"
+)
+
+var a *api
+var err error
+
+type handler func(http.ResponseWriter, *http.Request)
+
+func handle(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		err = t.Execute(w, infos)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write(toBytes(err.Error()))
+			return
+		}
+	case http.MethodPost:
+		port := r.URL.Query().Get("port")
+		if port == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write(toBytes("No port provided."))
+			return
+		}
+		a, err = newAPI(localhost, port)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write(toBytes(err.Error()))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write(toBytes("Connected to port: " + port))
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		w.Write(toBytes("404 Not Found!"))
+	}
+}
+
+func projectRootRequest(w http.ResponseWriter, r *http.Request) {
+	getResponse(w, r, &m.APIMessage{MessageType: m.APIMessage_GetProjectRootRequest, ProjectRootRequest: &m.GetProjectRootRequest{}}, http.MethodGet)
+}
+
+func installationRootRequest(w http.ResponseWriter, r *http.Request) {
+	getResponse(w, r, &m.APIMessage{MessageType: m.APIMessage_GetInstallationRootRequest, InstallationRootRequest: &m.GetInstallationRootRequest{}}, http.MethodGet)
+}
+
+func libPathRequest(w http.ResponseWriter, r *http.Request) {
+	lang := r.URL.Query().Get("pluginName")
+	getResponse(w, r, &m.APIMessage{MessageType: m.APIMessage_GetLanguagePluginLibPathRequest, LibPathRequest: &m.GetLanguagePluginLibPathRequest{Language: lang}}, http.MethodGet)
+}
+
+func allStepsRequest(w http.ResponseWriter, r *http.Request) {
+	getResponse(w, r, &m.APIMessage{MessageType: m.APIMessage_GetAllStepsRequest, AllStepsRequest: &m.GetAllStepsRequest{}}, http.MethodGet)
+}
+
+func allConceptsRequest(w http.ResponseWriter, r *http.Request) {
+	getResponse(w, r, &m.APIMessage{MessageType: m.APIMessage_GetAllConceptsRequest, AllConceptsRequest: &m.GetAllConceptsRequest{}}, http.MethodGet)
+}
+
+func specsRequest(w http.ResponseWriter, r *http.Request) {
+	getResponse(w, r, &m.APIMessage{MessageType: m.APIMessage_SpecsRequest, SpecsRequest: &m.SpecsRequest{}}, http.MethodGet)
+}
+
+func formatSpecsRequest(w http.ResponseWriter, r *http.Request) {
+	specs := strings.Split(r.URL.Query().Get("specs"), "\n")
+	getResponse(w, r, &m.APIMessage{MessageType: m.APIMessage_FormatSpecsRequest, FormatSpecsRequest: &m.FormatSpecsRequest{Specs: specs}}, http.MethodPost)
+}
+
+func refactoringRequest(w http.ResponseWriter, r *http.Request) {
+	oldStep := r.URL.Query().Get("old")
+	newStep := r.URL.Query().Get("new")
+	getResponse(w, r, &m.APIMessage{MessageType: m.APIMessage_PerformRefactoringRequest, PerformRefactoringRequest: &m.PerformRefactoringRequest{OldStep: oldStep, NewStep: newStep}}, http.MethodPost)
+}
+
+func stepValueRequest(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	step := q.Get("stepText")
+	hasInlineTable, err := strconv.ParseBool(q.Get("hasInlineTable"))
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write(toBytes(err.Error()))
+		return
+	}
+	getResponse(w, r, &m.APIMessage{MessageType: m.APIMessage_GetStepValueRequest, StepValueRequest: &m.GetStepValueRequest{StepText: step, HasInlineTable: hasInlineTable}}, http.MethodGet)
+}
+
+func getResponse(w http.ResponseWriter, r *http.Request, msg *m.APIMessage, method string) {
+	switch r.Method {
+	case method:
+		if a == nil {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write(toBytes("Before making api requests, please connect to a Gauge api process."))
+			return
+		}
+		resp, err := a.getResponse(msg)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write(toBytes(err.Error()))
+			return
+		}
+		e := json.NewEncoder(w)
+		e.SetEscapeHTML(false)
+		e.SetIndent("", "\t")
+		err = e.Encode(resp)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write(toBytes(err.Error()))
+			return
+		}
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		w.Write(toBytes("404 Not Found!"))
+	}
+}
+
+func toBytes(s string) []byte {
+	return []byte(s)
+}

--- a/debug/handler_test.go
+++ b/debug/handler_test.go
@@ -1,0 +1,107 @@
+package debug
+
+import (
+	"bytes"
+	"html/template"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+type writer struct {
+	t *testing.T
+	c string
+	h int
+}
+
+func (w *writer) Header() http.Header {
+	return nil
+}
+
+func (w *writer) Write(b []byte) (int, error) {
+	w.c += string(b)
+	return len(b), nil
+}
+
+func (w *writer) WriteHeader(i int) {
+	w.h = i
+}
+
+func TestHandleWithGetRequest(test *testing.T) {
+	w := &writer{t: test}
+	r := &http.Request{Method: http.MethodGet}
+	infos = []processInfo{{Port: "1234", Cwd: "CWD", Pid: 1234}}
+	t, _ = template.New("html").Parse(html)
+
+	handle(w, r)
+
+	var tpl bytes.Buffer
+	t.Execute(&tpl, infos)
+	expectedMessage := tpl.String()
+	if w.c != expectedMessage || w.h != 0 {
+		test.Errorf("Test failed: expected { message: %s, header: %d}, actual { message: %s, header: %d}", expectedMessage, 0, w.c, w.h)
+	}
+}
+
+func TestHandleWithPostRequestWithNoPort(test *testing.T) {
+	w := &writer{t: test}
+	r := &http.Request{Method: http.MethodPost, URL: &url.URL{RawQuery: ""}}
+
+	handle(w, r)
+
+	expectedMessage := "No port provided."
+	if w.c != expectedMessage || w.h != http.StatusBadRequest {
+		test.Errorf("Test failed: expected { message: %s, header: %d}, actual { message: %s, header: %d}", expectedMessage, http.StatusBadRequest, w.c, w.h)
+	}
+}
+
+func TestHandleWithPostRequestWithWrongPort(test *testing.T) {
+	w := &writer{t: test}
+	r := &http.Request{Method: http.MethodPost, URL: &url.URL{RawQuery: "port=1567777"}}
+
+	handle(w, r)
+
+	expectedMessage := "dial tcp: address 1567777: invalid port"
+	if w.c != expectedMessage || w.h != http.StatusInternalServerError {
+		test.Errorf("Test failed: expected { message: %s, header: %d}, actual { message: %s, header: %d}", expectedMessage, http.StatusInternalServerError, w.c, w.h)
+	}
+}
+
+func TestHandleWithInvalidRequestMethod(test *testing.T) {
+	w := &writer{t: test}
+	r := &http.Request{Method: http.MethodPut}
+
+	handle(w, r)
+
+	expectedMessage := "404 Not Found!"
+	if w.c != expectedMessage || w.h != http.StatusNotFound {
+		test.Errorf("Test failed: expected { message: %s, header: %d}, actual { message: %s, header: %d}", expectedMessage, http.StatusNotFound, w.c, w.h)
+	}
+}
+
+func TestGetResponseWithInvalidRequestMethod(test *testing.T) {
+	w := &writer{t: test}
+	r := &http.Request{Method: http.MethodPut}
+
+	getResponse(w, r, nil, http.MethodPost)
+
+	expectedMessage := "404 Not Found!"
+	if w.c != expectedMessage || w.h != http.StatusNotFound {
+		test.Errorf("Test failed: expected { message: %s, header: %d}, actual { message: %s, header: %d}", expectedMessage, http.StatusNotFound, w.c, w.h)
+	}
+
+}
+
+func TestGetResponseWithValidRequestMethod(test *testing.T) {
+	w := &writer{t: test}
+	r := &http.Request{Method: http.MethodPost}
+	a = nil
+
+	getResponse(w, r, nil, http.MethodPost)
+
+	expectedMessage := "Before making api requests, please connect to a Gauge api process."
+	if w.c != expectedMessage || w.h != http.StatusBadRequest {
+		test.Errorf("Test failed: expected { message: %s, header: %d}, actual { message: %s, header: %d}", expectedMessage, http.StatusBadRequest, w.c, w.h)
+	}
+
+}

--- a/debug/html.go
+++ b/debug/html.go
@@ -1,0 +1,302 @@
+package debug
+
+var html = `
+<html>
+
+<head>
+    <title>
+        Gauge Debug API
+    </title>
+    <link href="https://getgauge.io/assets/images/favicons/favicon.ico" rel="shortcut icon" type="image/ico">
+    <script lang="javascript">
+        const send = () => {
+            var http = new XMLHttpRequest();
+            const r = document.getElementById("request").value;
+            let method = "GET";
+            let params = "";
+            if (r == "libPathRequest") {
+                params = "pluginName=" + document.getElementById("pluginName").value;
+            } else if (r == "stepValueRequest") {
+                params = "stepText=" + document.getElementById("stepText").value;
+                params += "&hasInlineTable=" + document.getElementById("hasInlineTable").checked;
+            } else if (r == "formatSpecsRequest") {
+                method = "POST";
+                params = "specs=" + document.getElementById("specs").value;
+            } else if (r == "refactoringRequest") {
+                method = "POST";
+                params = "old=" + document.getElementById("old").value;
+                params += "&new=" + document.getElementById("new").value;
+            }
+            http.open(method, "/" + r + "?" + params, true);
+            http.onreadystatechange = function() {
+                document.getElementById("output").innerHTML = "<pre><xmp>" + http.responseText + "</xmp></pre>";
+                document.getElementById("output").hidden = false;
+            }
+            http.send();
+        }
+
+        const connect = () => {
+            var http = new XMLHttpRequest();
+            const r = document.getElementById("request").value;
+            const e = document.querySelector('input[name="process"]:checked');
+            if (!e) {
+                alert("Please select a port");
+                return;
+            }
+            let params = "port=" + e.value;
+            http.open("POST", "/?" + params, true);
+            http.onreadystatechange = function() {
+                document.getElementById("connectOutput").innerHTML = "<pre>" + http.responseText + "</pre>";
+                if (http.readyState == 4 && http.status == 200)
+                    document.getElementById("requests").hidden = false;
+            }
+            http.send();
+        }
+
+        const requestChange = (v) => {
+            [].slice.call(document.getElementsByClassName("options")).forEach((e) => e.hidden = true)
+            const e = document.getElementById(v);
+            if (e) e.hidden = false;
+        }
+    </script>
+    <style>
+        body {
+            font-family: 'Open Sans', sans-serif;
+            text-align: center;
+            margin: 0px;
+        }
+
+        table {
+            border-collapse: collapse;
+            width: 100%;
+        }
+
+        th,
+        td {
+            border-bottom: 1px solid #ddd;
+            padding: 10px;
+            text-align: left;
+        }
+
+        tr:hover {
+            background-color: #f5f5f5
+        }
+
+        th {
+            background-color: #464545;
+            color: #ffffff;
+        }
+
+        input[type=button] {
+            text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.12);
+            border: 1px solid rgba(0, 0, 0, 0.12);
+            margin-top: 1%;
+            background: #464545;
+            color: #ffffff;
+            font: 400 18px/1.5 "Roboto Slab", "Helvetica Neue", Helvetica, Arial, sans-serif;
+            border-radius: 10px 10px 10px 10px;
+            -webkit-border-radius: 10px 10px 10px 10px;
+            -moz-border-radius: 10px 10px 10px 10px;
+            padding-top: 0.5%;
+            padding-bottom: 0.5%;
+            padding-right: 1%;
+            padding-left: 1%;
+        }
+
+        input[type=button]:hover {
+            background: #5d5b5b;
+            -moz-box-shadow: inset 0px 2px 2px 0px rgba(255, 255, 255, 0.28);
+            -webkit-box-shadow: inset 0px 2px 2px 0px rgba(255, 255, 255, 0.28);
+            box-shadow: inset 0px 2px 2px 0px rgba(255, 255, 255, 0.28);
+            cursor: pointer;
+        }
+
+        div {
+            border-radius: 20px
+        }
+
+        input[type=button]:focus {
+            outline: none;
+        }
+
+        #output {
+            text-align: left;
+            background: #E5E9EB;
+            border-radius: 20px;
+            padding: 1%;
+            margin-top: 1%;
+            overflow: auto;
+        }
+
+        #connectOutput {
+            margin-top: 0.5%;
+        }
+
+        th:first-child {
+            border-top-left-radius: 20px;
+        }
+
+        th:last-child {
+            border-top-right-radius: 20px;
+        }
+
+        .options {
+            margin-top: 1%;
+        }
+
+        textarea {
+            width: 30%;
+            height: 50px;
+            font-size: 14px;
+            font-family: "Courier New", Courier, monospace;
+        }
+
+        .menu {
+            width: 100%;
+            height: 65px;
+            background: #464545;
+            z-index: 100;
+            -webkit-touch-callout: none;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            border-bottom: 2px solid #7b7b7b;
+            margin-bottom: 1%;
+            border-radius: 0px;
+        }
+
+        .back {
+            position: absolute;
+            width: 90px;
+            height: 50px;
+            top: 5px;
+            left: 0px;
+            color: #000000;
+            line-height: 45px;
+            font-size: 40px;
+            padding-left: 10px;
+            cursor: pointer;
+            transition: .15s all;
+            text-decoration: none;
+        }
+
+        .back img {
+            position: absolute;
+            top: 10px;
+            left: 50px;
+            height: 35px;
+            margin-left: 15px;
+        }
+
+        .beta {
+            position: relative;
+            background: #f5c10e;
+            color: #000;
+            padding: 2px 6px;
+            font-size: 12px;
+            text-transform: uppercase;
+            top: 6px;
+            left: 177px;
+            border-radius: 6px;
+        }
+
+        .back:active {
+            background: rgba(0, 0, 0, 0.15);
+        }
+
+        select {
+            height: 35px;
+            width: 200px;
+            font-size: 14px;
+            margin-right: 2%;
+        }
+
+        select:focus {
+            outline: none;
+        }
+
+        input[type="text"] {
+            height: 30px;
+            width: 300px;
+            font-size: 14px;
+            font-family: "Courier New", Courier, monospace;
+            margin-right: 50px;
+        }
+
+        #requests {
+            border: 1px solid #9a988f;
+            padding-bottom: 1%;
+            margin-top: 1%;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="menu">
+        <a href="http://getgauge.io" target="_blank" class="back"><img src="https://getgauge.io/assets/images/Gauge_logo.svg" draggable="false" /><span class="beta">BETA</span></a>
+    </div>
+    <div style="margin-right: 1%; margin-left: 1%;">
+        <div style="border: 1px solid #9a988f;padding-bottom: 0.5%;">
+            <table>
+                <tr>
+                    <th></th>
+                    <th>PID</th>
+                    <th>Port</th>
+                    <th>CWD</th>
+                </tr>
+                {{range .}}
+                <tr>
+                    <td><input type="radio" name="process" value="{{.Port}}"></td>
+                    <td>{{.Pid}}</td>
+                    <td>{{.Port}}</td>
+                    <td>{{.Cwd}}</td>
+                </tr>
+                {{end}}
+            </table>
+            <input type="button" value="Connect" onclick="connect()" />
+            <div id="connectOutput"></div>
+        </div>
+        <div id="requests" hidden>
+            <select id="request" onchange="requestChange(this.value)">
+                <option value="projectRootRequest">ProjectRootRequest</option>
+                <option value="installationRootRequest">InstallationRootRequest</option>
+                <option value="libPathRequest">LibPathRequest</option>
+                <option value="allStepsRequest">AllStepsRequest</option>
+                <option value="allConceptsRequest">AllConceptsRequest</option>
+                <option value="specsRequest">SpecsRequest</option>
+                <option value="stepValueRequest">StepValueRequest</option>
+                <option value="formatSpecsRequest">FormatSpecsRequest</option>
+                <option value="refactoringRequest">RefactoringRequest</option>
+            </select>
+
+            <input type="button" value="Send" onclick="send()" />
+
+            <div id="stepValueRequest" class="options" hidden>
+                <textarea id="stepText" placeholder="Enter step text..."></textarea><br><br>
+                <label for="hasInlineTable">Has inline table</label>
+                <input type="checkbox" id="hasInlineTable" />
+            </div>
+
+            <div id="libPathRequest" class="options" hidden>
+                <label for="pluginName">Enter plugin name: </label>
+                <input type="text" id="pluginName" />
+            </div>
+
+            <div id="formatSpecsRequest" class="options" hidden>
+                <label for="specs">Enter spec file(s) path</label>
+                <textarea id="specs" placeholder="specs/example.spec&#10;specs/example1.spec"></textarea>
+            </div>
+
+            <div id="refactoringRequest" class="options" hidden>
+                <label for="old">Old Step: </label>
+                <input type="text" id="old" />
+                <label for="new">New Step: </label>
+                <input type="text" id="new" />
+            </div>
+        </div>
+        <div id="output" hidden></div>
+    </div>
+</body>
+
+</html>
+`

--- a/debug/process.go
+++ b/debug/process.go
@@ -1,0 +1,114 @@
+package debug
+
+import (
+	"fmt"
+	"os"
+
+	m "github.com/getgauge/gauge/gauge_messages"
+	"github.com/getgauge/gauge/logger"
+	"github.com/shirou/gopsutil/process"
+)
+
+const (
+	localhost = "localhost"
+)
+
+type processInfo struct {
+	Port string
+	Cwd  string
+	Pid  int
+}
+
+func getPInfos() []processInfo {
+	pids, err := process.Pids()
+	if err != nil {
+		logger.Fatalf(err.Error())
+	}
+	processes, errors := getProcesses(pids)
+	for _, e := range errors {
+		logger.Errorf(e)
+	}
+	return getProcessInfo(processes)
+}
+
+func getProcessInfo(processes []*process.Process) []processInfo {
+	var infos []processInfo
+	for _, p := range processes {
+		port, err := getPort(p)
+		if err != nil {
+			logger.Errorf(err.Error())
+			continue
+		}
+		cwd, err := p.Cwd()
+		if err != nil {
+			api, err := newAPI(localhost, port)
+			if err != nil {
+				cwd = "N/A"
+			} else {
+				msg, err := api.getResponse(&m.APIMessage{MessageType: m.APIMessage_GetProjectRootRequest, ProjectRootRequest: &m.GetProjectRootRequest{}})
+				if err != nil {
+					cwd = "N/A"
+				} else {
+					cwd = msg.ProjectRootResponse.ProjectRoot
+				}
+				api.close()
+			}
+		}
+		infos = append(infos, processInfo{Port: port, Cwd: cwd, Pid: int(p.Pid)})
+	}
+	return infos
+}
+
+func getPort(p *process.Process) (string, error) {
+	args, err := p.CmdlineSlice()
+	if err == nil {
+		if len(args) > 3 {
+			return args[len(args)-1], nil
+		}
+	}
+	conns, err := p.Connections()
+	if err != nil {
+		return "", fmt.Errorf("Cannot find a port for the process %d", p.Pid)
+	}
+	var port uint32 = 0
+	for _, c := range conns {
+		p := fmt.Sprintf("%d", c.Laddr.Port)
+		api, err := newAPI(localhost, p)
+		if err == nil {
+			port = c.Laddr.Port
+			api.close()
+			break
+		}
+	}
+	if port == 0 {
+		return "", fmt.Errorf("Cannot find a port for the process %d", p.Pid)
+	}
+	return fmt.Sprintf("%d", port), nil
+}
+
+func getProcesses(pids []int32) ([]*process.Process, []string) {
+	var errors []string
+	var processes []*process.Process
+	for _, pid := range pids {
+		if int(pid) == os.Getpid() {
+			continue
+		}
+		p, err := process.NewProcess(pid)
+		if err != nil {
+			logger.Errorf(err.Error())
+		}
+		name, err := p.Name()
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("Process name error for pid: %v. Error: %v", pid, err))
+		}
+		if name == "gauge" {
+			_, err = p.CmdlineSlice()
+			if err != nil {
+				errors = append(errors, fmt.Sprintf("Process Cmd line slice error for pid: %v. Error: %v", p.Pid, err))
+			} else {
+				processes = append(processes, p)
+			}
+		}
+	}
+	return processes, errors
+}

--- a/debug/server.go
+++ b/debug/server.go
@@ -1,0 +1,51 @@
+package debug
+
+import (
+	"fmt"
+
+	"net"
+
+	"net/http"
+
+	"html/template"
+
+	"github.com/getgauge/gauge/logger"
+)
+
+var infos []processInfo
+var t *template.Template
+
+func Start() {
+	infos = getPInfos()
+	if len(infos) < 1 {
+		logger.Fatalf("No running gauge process found.")
+	}
+	t, err = template.New("html").Parse(html)
+	if err != nil {
+		logger.Fatalf("Cannot load HTML template. Error: ", err.Error())
+	}
+
+	http.HandleFunc("/", handle)
+	http.HandleFunc("/projectRootRequest", projectRootRequest)
+	http.HandleFunc("/installationRootRequest", installationRootRequest)
+	http.HandleFunc("/libPathRequest", libPathRequest)
+	http.HandleFunc("/allStepsRequest", allStepsRequest)
+	http.HandleFunc("/allConceptsRequest", allConceptsRequest)
+	http.HandleFunc("/specsRequest", specsRequest)
+	http.HandleFunc("/stepValueRequest", stepValueRequest)
+	http.HandleFunc("/formatSpecsRequest", formatSpecsRequest)
+	http.HandleFunc("/refactoringRequest", refactoringRequest)
+
+	p := getFreePort()
+	logger.Info("Starting server at http://127.0.0.1:%d", p)
+	logger.Fatalf(http.ListenAndServe(fmt.Sprintf(":%d", p), nil).Error())
+}
+
+func getFreePort() int {
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{Port: 0})
+	if err != nil {
+		logger.Fatalf(err.Error())
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}

--- a/gauge.go
+++ b/gauge.go
@@ -40,6 +40,7 @@ import (
 	"github.com/getgauge/gauge/validation"
 	"github.com/getgauge/gauge/version"
 
+	"github.com/getgauge/gauge/debug"
 	"github.com/getgauge/gauge/plugin/install"
 	"github.com/getgauge/gauge/projectInit"
 	"github.com/getgauge/gauge/util"
@@ -80,6 +81,7 @@ var listTemplates = flag.Bool([]string{"-list-templates"}, false, "Lists all the
 var machineReadable = flag.Bool([]string{"-machine-readable"}, false, "Used with `--version` to produce JSON output of currently installed Gauge and plugin versions. e.g: gauge --version --machine-readable")
 var runFailed = flag.Bool([]string{"-failed"}, false, "Run only the scenarios failed in previous run. Eg: gauge --failed")
 var docs = flag.String([]string{"-docs"}, "", "Generate documenation using specified plugin. Eg: gauge --docs <plugin name> specs/")
+var debugApi = flag.Bool([]string{"-debug-api"}, false, "Starts a local web server to debug gauge API's started by IDE's. Eg: gauge --debug-api")
 
 func main() {
 	flag.Parse()
@@ -130,6 +132,8 @@ func main() {
 	} else if flag.NFlag() == 0 && len(flag.Args()) == 0 {
 		printUsage()
 		os.Exit(0)
+	} else if *debugApi {
+		debug.Start()
 	} else if validGaugeProject {
 		var specDirs = []string{common.SpecsDirectoryName}
 		if len(flag.Args()) > 0 {


### PR DESCRIPTION
Starts a local web server to debug gauge API's started by IDE's.

**Usage**:

* Open one or more `gauge` projects in IntelliJ(use Gauge IntelliJ Nightly plugin).
* Run `gauge --debug-api` in the terminal(working directory doesn't matter), navigate to the URL shown in the console output.
* Select a port from the list of ports shown and click on connect button.
* Select a request from the dropdown, fill the fields if required and click on send button.
* The result will be shown as JSON at the end of the page

**Supported API Requests:**
* `projectRootRequest`
* `installationRootRequest`
* `libPathRequest`
* `allStepsRequest`
* `allConceptsRequest`
* `specsRequest`
* `stepValueRequest`
* `formatSpecsRequest`
* `refactoringRequest`

> `extractToConceptRequest` is not supported.

**Dependencies added:**

* https://github.com/shirou/gopsutil: To get process connections, PID, CWD.

**Executable size[Mac]:**

Before: 13.9 MB
After: 16.3 MB

> I have only tested it on Mac. It was just a spike, we can decide if we want this feature in Gauge or not.