### PR TITLE
#641 Adding order flag

### DIFF
--- a/execution/stream/stream.go
+++ b/execution/stream/stream.go
@@ -217,7 +217,10 @@ func setFlags(req *gm.ExecutionRequest) []error {
 	reporter.NumberOfExecutionStreams = streams
 	filter.NumberOfExecutionStreams = streams
 	execution.Strategy = strings.ToLower(req.GetStrategy().String())
-	filter.DoNotRandomize = req.GetSort()
+	//TODO: should be changed to use Order instead
+	if req.GetSort() {
+		filter.Order = "sort"
+	}
 	reporter.Verbose = true
 	logger.Initialize(strings.ToLower(req.GetLogLevel().String()))
 	if req.GetWorkingDir() != "" {
@@ -243,6 +246,6 @@ func resetFlags() {
 	reporter.NumberOfExecutionStreams = cores
 	filter.NumberOfExecutionStreams = cores
 	execution.Strategy = "lazy"
-	filter.DoNotRandomize = false
+	filter.Order = ""
 	util.SetWorkingDir(config.ProjectRoot)
 }

--- a/execution/stream/stream_test.go
+++ b/execution/stream/stream_test.go
@@ -398,7 +398,7 @@ func (s *MySuite) TestSetFlags(c *C) {
 	c.Assert(execution.NumberOfExecutionStreams, Equals, 3)
 	c.Assert(reporter.NumberOfExecutionStreams, Equals, 3)
 	c.Assert(filter.NumberOfExecutionStreams, Equals, 3)
-	c.Assert(filter.DoNotRandomize, Equals, true)
+	c.Assert(filter.Order, Equals, "sort")
 	c.Assert(filter.ExecuteTags, Equals, "tag1 & tag2")
 	c.Assert(reporter.Verbose, Equals, true)
 	c.Assert(reporter.IsParallel, Equals, true)
@@ -427,7 +427,7 @@ func (s *MySuite) TestResetFlags(c *C) {
 	execution.NumberOfExecutionStreams = 1
 	reporter.NumberOfExecutionStreams = 2
 	filter.NumberOfExecutionStreams = 3
-	filter.DoNotRandomize = true
+	filter.Order = "sort"
 	resetFlags()
 
 	cores := util.NumberOfCores()
@@ -436,7 +436,7 @@ func (s *MySuite) TestResetFlags(c *C) {
 	c.Assert(execution.NumberOfExecutionStreams, Equals, cores)
 	c.Assert(reporter.NumberOfExecutionStreams, Equals, cores)
 	c.Assert(filter.NumberOfExecutionStreams, Equals, cores)
-	c.Assert(filter.DoNotRandomize, Equals, false)
+	c.Assert(filter.Order, Equals, "")
 	c.Assert(filter.ExecuteTags, Equals, "")
 	c.Assert(reporter.Verbose, Equals, false)
 	c.Assert(reporter.IsParallel, Equals, false)

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -7,9 +7,9 @@ import (
 )
 
 var ExecuteTags string
-var DoNotRandomize bool
 var Distribute int
 var NumberOfExecutionStreams int
+var Order string
 
 func FilterSpecs(specs []*gauge.Specification) []*gauge.Specification {
 	specs = applyFilters(specs, specsFilters())
@@ -23,7 +23,7 @@ func FilterSpecs(specs []*gauge.Specification) []*gauge.Specification {
 }
 
 func specsFilters() []specsFilter {
-	return []specsFilter{&tagsFilter{ExecuteTags}, &specsGroupFilter{Distribute, NumberOfExecutionStreams}, &specRandomizer{DoNotRandomize}}
+	return []specsFilter{&tagsFilter{ExecuteTags}, &specsGroupFilter{Distribute, NumberOfExecutionStreams}, &specOrder{Order}}
 }
 
 func applyFilters(specsToExecute []*gauge.Specification, filters []specsFilter) []*gauge.Specification {

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -12,7 +12,7 @@ var Distribute int
 var NumberOfExecutionStreams int
 
 func FilterSpecs(specs []*gauge.Specification) []*gauge.Specification {
-	specs = sortSpecsList(applyFilters(specs, specsFilters()))
+	specs = applyFilters(specs, specsFilters())
 	if ExecuteTags != "" && len(specs) > 0 {
 		logger.Debug("The following specifications satisfy filter criteria:")
 		for _, s := range specs {

--- a/filter/specsFilter.go
+++ b/filter/specsFilter.go
@@ -39,8 +39,8 @@ type specsGroupFilter struct {
 	execStreams int
 }
 
-type specRandomizer struct {
-	dontRandomize bool
+type specOrder struct {
+	order string
 }
 
 func (tagsFilter *tagsFilter) filter(specs []*gauge.Specification) []*gauge.Specification {
@@ -78,9 +78,11 @@ func DistributeSpecs(specifications []*gauge.Specification, distributions int) [
 	return s
 }
 
-func (randomizer *specRandomizer) filter(specs []*gauge.Specification) []*gauge.Specification {
-	if !randomizer.dontRandomize {
+func (specOrder *specOrder) filter(specs []*gauge.Specification) []*gauge.Specification {
+	if specOrder.order == "random" {
 		return shuffleSpecs(specs)
+	} else if specOrder.order == "sort" {
+		sortSpecsList(specs)
 	}
 	return specs
 }

--- a/filter/specsFilter.go
+++ b/filter/specsFilter.go
@@ -59,7 +59,7 @@ func (groupFilter *specsGroupFilter) filter(specs []*gauge.Specification) []*gau
 	if groupFilter.group < 1 || groupFilter.group > groupFilter.execStreams {
 		return make([]*gauge.Specification, 0)
 	}
-	group := DistributeSpecs(sortSpecsList(specs), groupFilter.execStreams)[groupFilter.group-1]
+	group := DistributeSpecs(specs, groupFilter.execStreams)[groupFilter.group-1]
 	if group == nil {
 		return make([]*gauge.Specification, 0)
 	}

--- a/gauge.go
+++ b/gauge.go
@@ -231,7 +231,7 @@ func initPackageFlags() {
 	execution.Strategy = *strategy
 	filter.ExecuteTags = *executeTags
 	if *doNotRandomize {
-		fmt.Println("This flag will be deprecated soon. Please user --order=sort instead")
+		fmt.Println("This flag will be deprecated soon. Please use --order=sort instead.")
 		filter.Order = "sort"
 	}
 	filter.Order = *order

--- a/gauge.go
+++ b/gauge.go
@@ -74,6 +74,7 @@ var distribute = flag.Int([]string{"g", "-group"}, -1, "Specify which group of s
 var workingDir = flag.String([]string{"-dir"}, ".", "Set the working directory for the current command, accepts a path relative to current directory.")
 var strategy = flag.String([]string{"-strategy"}, "lazy", "Set the parallelization strategy for execution. Possible options are: `eager`, `lazy`. Ex: gauge -p --strategy=\"eager\"")
 var doNotRandomize = flag.Bool([]string{"-sort", "s"}, false, "Run specs in Alphabetical Order. Eg: gauge -s specs")
+var order = flag.String([]string{"-order", "o"}, "", "Set the specs execution order. Possible options are: `random`, `sort`. Ex: gauge --order=\"random\"")
 var validate = flag.Bool([]string{"-validate", "#-check"}, false, "Check for validation and parse errors. Eg: gauge --validate specs")
 var updateAll = flag.Bool([]string{"-update-all"}, false, "Updates all the installed Gauge plugins. Eg: gauge --update-all")
 var checkUpdates = flag.Bool([]string{"-check-updates"}, false, "Checks for Gauge and plugins updates. Eg: gauge --check-updates")
@@ -229,7 +230,11 @@ func initPackageFlags() {
 	execution.InParallel = *parallel
 	execution.Strategy = *strategy
 	filter.ExecuteTags = *executeTags
-	filter.DoNotRandomize = *doNotRandomize
+	if *doNotRandomize {
+		fmt.Println("This flag will be deprecated soon. Please user --order=sort instead")
+		filter.Order = "sort"
+	}
+	filter.Order = *order
 	filter.Distribute = *distribute
 	filter.NumberOfExecutionStreams = *numberOfExecutionStreams
 	reporter.NumberOfExecutionStreams = *numberOfExecutionStreams

--- a/gauge/specCollection.go
+++ b/gauge/specCollection.go
@@ -42,9 +42,20 @@ func combineDataTableSpecs(s []*Specification) (specs [][]*Specification) {
 		combinedSpecs[spec.FileName] = append(combinedSpecs[spec.FileName], spec)
 	}
 	for _, spec := range s {
-		specs = append(specs, combinedSpecs[spec.FileName])
+		if !hasSpec(specs, spec.FileName) {
+			specs = append(specs, combinedSpecs[spec.FileName])
+		}
 	}
 	return
+}
+
+func hasSpec(specs [][]*Specification, fileName string) bool {
+	for _, s := range specs {
+		if s[0].FileName == fileName {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *SpecCollection) Add(spec *Specification) {

--- a/gauge/specCollection.go
+++ b/gauge/specCollection.go
@@ -42,20 +42,12 @@ func combineDataTableSpecs(s []*Specification) (specs [][]*Specification) {
 		combinedSpecs[spec.FileName] = append(combinedSpecs[spec.FileName], spec)
 	}
 	for _, spec := range s {
-		if !hasSpec(specs, spec.FileName) {
+		if _, ok:= combinedSpecs[spec.FileName]; ok {
 			specs = append(specs, combinedSpecs[spec.FileName])
+			delete(combinedSpecs, spec.FileName)
 		}
 	}
 	return
-}
-
-func hasSpec(specs [][]*Specification, fileName string) bool {
-	for _, s := range specs {
-		if s[0] != nil && s[0].FileName == fileName {
-			return true
-		}
-	}
-	return false
 }
 
 func (s *SpecCollection) Add(spec *Specification) {

--- a/gauge/specCollection.go
+++ b/gauge/specCollection.go
@@ -41,8 +41,8 @@ func combineDataTableSpecs(s []*Specification) (specs [][]*Specification) {
 	for _, spec := range s {
 		combinedSpecs[spec.FileName] = append(combinedSpecs[spec.FileName], spec)
 	}
-	for _, v := range combinedSpecs {
-		specs = append(specs, v)
+	for _, spec := range s {
+		specs = append(specs, combinedSpecs[spec.FileName])
 	}
 	return
 }

--- a/gauge/specCollection.go
+++ b/gauge/specCollection.go
@@ -51,7 +51,7 @@ func combineDataTableSpecs(s []*Specification) (specs [][]*Specification) {
 
 func hasSpec(specs [][]*Specification, fileName string) bool {
 	for _, s := range specs {
-		if s[0].FileName == fileName {
+		if s[0] != nil && s[0].FileName == fileName {
 			return true
 		}
 	}

--- a/gauge/specCollection_test.go
+++ b/gauge/specCollection_test.go
@@ -32,6 +32,12 @@ func TestGroupSpecCollection(t *testing.T) {
 	if !reflect.DeepEqual(set(want), set(got)) {
 		t.Errorf("Spec Collection Failed\n\tWant: %v\n\t Got:%v", want, got)
 	}
+
+	for key, value := range got {
+		if value[0].FileName != want[key][0].FileName {
+			t.Errorf("Spec Collection order is not maintained\n\tWant: %v\n\t Got:%v", want[key], got[key])
+		}
+	}
 }
 
 func set(s [][]*Specification) map[int][]*Specification {

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -118,20 +118,12 @@ func parseSpecsInDirs(conceptDictionary *gauge.ConceptDictionary, specDirs []str
 	}
 	var allSpecs []*gauge.Specification
 	for _, spec := range givenSpecs {
-		if !hasSpec(allSpecs, spec.FileName) {
+		if _, ok := specsMap[spec.FileName]; ok {
 			allSpecs = append(allSpecs, specsMap[spec.FileName])
+			delete(specsMap, spec.FileName)
 		}
 	}
 	return allSpecs, !passed
-}
-
-func hasSpec(specs []*gauge.Specification, fileName string) bool {
-	for _, spec := range specs {
-		if spec.FileName == fileName {
-			return true
-		}
-	}
-	return false
 }
 
 func getSpecWithScenarioIndex(specSource string, conceptDictionary *gauge.ConceptDictionary, buildErrors *gauge.BuildErrors) ([]*gauge.Specification, []*ParseResult) {

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -103,6 +103,7 @@ func addSpecsToMap(specs []*gauge.Specification, specsMap map[string]*gauge.Spec
 func parseSpecsInDirs(conceptDictionary *gauge.ConceptDictionary, specDirs []string, buildErrors *gauge.BuildErrors) ([]*gauge.Specification, bool) {
 	specsMap := make(map[string]*gauge.Specification)
 	passed := true
+	var givenSpecs []*gauge.Specification
 	for _, specSource := range specDirs {
 		var specs []*gauge.Specification
 		var specParseResults []*ParseResult
@@ -112,13 +113,25 @@ func parseSpecsInDirs(conceptDictionary *gauge.ConceptDictionary, specDirs []str
 			specs, specParseResults = ParseSpecFiles(util.GetSpecFiles(specSource), conceptDictionary, buildErrors)
 		}
 		passed = !HandleParseResult(specParseResults...) && passed
+		givenSpecs = append(givenSpecs, specs...)
 		addSpecsToMap(specs, specsMap)
 	}
 	var allSpecs []*gauge.Specification
-	for _, spec := range specsMap {
-		allSpecs = append(allSpecs, spec)
+	for _, spec := range givenSpecs {
+		if !hasSpec(allSpecs, spec.FileName) {
+			allSpecs = append(allSpecs, specsMap[spec.FileName])
+		}
 	}
 	return allSpecs, !passed
+}
+
+func hasSpec(specs []*gauge.Specification, fileName string) bool {
+	for _, spec := range specs {
+		if spec.FileName == fileName {
+			return true
+		}
+	}
+	return false
 }
 
 func getSpecWithScenarioIndex(specSource string, conceptDictionary *gauge.ConceptDictionary, buildErrors *gauge.BuildErrors) ([]*gauge.Specification, []*ParseResult) {

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -145,6 +145,16 @@ func (s *MySuite) TestSpecsFormArgsForMultipleIndexedArgsForOneSpec(c *C) {
 	c.Assert(len(specs[0].Scenarios), Equals, 2)
 }
 
+func (s *MySuite) TestSpecsFormArgsMaintainsOrderOfSpecsPassed(c *C) {
+	sampleSpec := filepath.Join("testdata", "sample.spec")
+	sample2Spec := filepath.Join("testdata", "sample2.spec")
+	specs, _ := parseSpecsInDirs(gauge.NewConceptDictionary(), []string{sample2Spec, sampleSpec}, gauge.NewBuildErrors())
+
+	c.Assert(len(specs), Equals, 2)
+	c.Assert(specs[0].Heading.Value, Equals, "Sample 2")
+	c.Assert(specs[1].Heading.Value, Equals, "Sample")
+}
+
 func (s *MySuite) TestToCheckIfItsIndexedSpec(c *C) {
 	c.Assert(isIndexedSpec("specs/hello_world:as"), Equals, false)
 	c.Assert(isIndexedSpec("specs/hello_world.spec:0"), Equals, true)

--- a/parser/testdata/sample2.spec
+++ b/parser/testdata/sample2.spec
@@ -1,0 +1,7 @@
+# Sample 2
+
+## Scenario1
+* step1
+
+## Scenario2
+* step2


### PR DESCRIPTION
Added a flag `--order`.
It accepts two values `sort` and `random`.
If the flag is not specified the order mentioned by user/obtained from file system is maintained.