### PR TITLE
De-duplicating specs given before parsing.

### DIFF
--- a/filter/specItemFilter.go
+++ b/filter/specItemFilter.go
@@ -189,17 +189,6 @@ func (filter *ScenarioFilterBasedOnTags) parseTagExpression() (tagExpressionPart
 	return
 }
 
-func FilterSpecsItems(specs []*gauge.Specification, filter gauge.SpecItemFilter) []*gauge.Specification {
-	filteredSpecs := make([]*gauge.Specification, 0)
-	for _, spec := range specs {
-		spec.Filter(filter)
-		if len(spec.Scenarios) != 0 {
-			filteredSpecs = append(filteredSpecs, spec)
-		}
-	}
-	return filteredSpecs
-}
-
 func filterSpecsByTags(specs []*gauge.Specification, tagExpression string) []*gauge.Specification {
 	filteredSpecs := make([]*gauge.Specification, 0)
 	for _, spec := range specs {

--- a/filter/specItemFilter.go
+++ b/filter/specItemFilter.go
@@ -33,19 +33,24 @@ import (
 )
 
 type scenarioFilterBasedOnSpan struct {
-	lineNumber int
+	lineNumbers []int
 }
 type ScenarioFilterBasedOnTags struct {
 	specTags      []string
 	tagExpression string
 }
 
-func NewScenarioFilterBasedOnSpan(lineNumber int) *scenarioFilterBasedOnSpan {
-	return &scenarioFilterBasedOnSpan{lineNumber}
+func NewScenarioFilterBasedOnSpan(lineNumbers []int) *scenarioFilterBasedOnSpan {
+	return &scenarioFilterBasedOnSpan{lineNumbers}
 }
 
 func (filter *scenarioFilterBasedOnSpan) Filter(item gauge.Item) bool {
-	return (item.Kind() == gauge.ScenarioKind) && !(item.(*gauge.Scenario).InSpan(filter.lineNumber))
+	for _, lineNumber := range filter.lineNumbers {
+		if (item.Kind() == gauge.ScenarioKind) && item.(*gauge.Scenario).InSpan(lineNumber) {
+			return false
+		}
+	}
+	return true
 }
 
 func newScenarioFilterBasedOnTags(specTags []string, tagExp string) *ScenarioFilterBasedOnTags {

--- a/filter/specItemFilter_test.go
+++ b/filter/specItemFilter_test.go
@@ -209,7 +209,7 @@ func (s *MySuite) TestScenarioSpanFilter(c *C) {
 		Scenarios: []*gauge.Scenario{scenario1, scenario2, scenario3, scenario4},
 	}
 
-	spec.Filter(NewScenarioFilterBasedOnSpan(8))
+	spec.Filter(NewScenarioFilterBasedOnSpan([]int{8}))
 
 	c.Assert(len(spec.Scenarios), Equals, 1)
 	c.Assert(spec.Scenarios[0], Equals, scenario3)
@@ -237,7 +237,7 @@ func (s *MySuite) TestScenarioSpanFilterLastScenario(c *C) {
 		Scenarios: []*gauge.Scenario{scenario1, scenario2, scenario3, scenario4},
 	}
 
-	spec.Filter(NewScenarioFilterBasedOnSpan(13))
+	spec.Filter(NewScenarioFilterBasedOnSpan([]int{13}))
 	c.Assert(len(spec.Scenarios), Equals, 1)
 	c.Assert(spec.Scenarios[0], Equals, scenario4)
 
@@ -265,7 +265,7 @@ func (s *MySuite) TestScenarioSpanFilterFirstScenario(c *C) {
 		Scenarios: []*gauge.Scenario{scenario1, scenario2, scenario3, scenario4},
 	}
 
-	spec.Filter(NewScenarioFilterBasedOnSpan(2))
+	spec.Filter(NewScenarioFilterBasedOnSpan([]int{2}))
 
 	c.Assert(len(spec.Scenarios), Equals, 1)
 	c.Assert(spec.Scenarios[0], Equals, scenario1)
@@ -282,7 +282,7 @@ func (s *MySuite) TestScenarioSpanFilterForSingleScenarioSpec(c *C) {
 		Scenarios: []*gauge.Scenario{scenario1},
 	}
 
-	spec.Filter(NewScenarioFilterBasedOnSpan(3))
+	spec.Filter(NewScenarioFilterBasedOnSpan([]int{3}))
 	c.Assert(len(spec.Scenarios), Equals, 1)
 	c.Assert(spec.Scenarios[0], Equals, scenario1)
 }
@@ -297,8 +297,38 @@ func (s *MySuite) TestScenarioSpanFilterWithWrongScenarioIndex(c *C) {
 		Scenarios: []*gauge.Scenario{scenario1},
 	}
 
-	spec.Filter(NewScenarioFilterBasedOnSpan(5))
+	spec.Filter(NewScenarioFilterBasedOnSpan([]int{5}))
 	c.Assert(len(spec.Scenarios), Equals, 0)
+}
+
+func (s *MySuite) TestScenarioSpanFilterWithMultipleLineNumbers(c *C) {
+	scenario1 := &gauge.Scenario{
+		Heading: &gauge.Heading{Value: "First Scenario"},
+		Span:    &gauge.Span{Start: 1, End: 3},
+	}
+	scenario2 := &gauge.Scenario{
+		Heading: &gauge.Heading{Value: "Second Scenario"},
+		Span:    &gauge.Span{Start: 4, End: 6},
+	}
+	scenario3 := &gauge.Scenario{
+		Heading: &gauge.Heading{Value: "Third Scenario"},
+		Span:    &gauge.Span{Start: 7, End: 10},
+	}
+	scenario4 := &gauge.Scenario{
+		Heading: &gauge.Heading{Value: "Fourth Scenario"},
+		Span:    &gauge.Span{Start: 11, End: 15},
+	}
+	spec := &gauge.Specification{
+		Items:     []gauge.Item{scenario1, scenario2, scenario3, scenario4},
+		Scenarios: []*gauge.Scenario{scenario1, scenario2, scenario3, scenario4},
+	}
+
+	spec.Filter(NewScenarioFilterBasedOnSpan([]int{3, 13}))
+
+	c.Assert(len(spec.Scenarios), Equals, 2)
+	c.Assert(spec.Scenarios[0], Equals, scenario1)
+	c.Assert(spec.Scenarios[1], Equals, scenario4)
+
 }
 
 func (s *MySuite) TestToFilterSpecsByTagExpOfTwoTags(c *C) {

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -92,7 +92,7 @@ type specFile struct {
 }
 
 // parseSpecsInDirs parses all the specs in list of dirs given.
-// It also merges the scenarios belonging to same spec which are passed as different arguments in `specDirs`
+// It also de-duplicates all specs passed through `specDirs` before parsing specs.
 func parseSpecsInDirs(conceptDictionary *gauge.ConceptDictionary, specDirs []string, buildErrors *gauge.BuildErrors) ([]*gauge.Specification, bool) {
 	passed := true
 	givenSpecs, specFiles := getAllSpecFiles(specDirs)
@@ -105,7 +105,7 @@ func parseSpecsInDirs(conceptDictionary *gauge.ConceptDictionary, specDirs []str
 		i, _ := getIndexFor(specFiles, spec.FileName)
 		specFile := specFiles[i]
 		if len(specFile.indices) > 0 {
-			filter.FilterSpecsItems(specs, filter.NewScenarioFilterBasedOnSpan(specFile.indices))
+			spec.Filter(filter.NewScenarioFilterBasedOnSpan(specFile.indices))
 		}
 		allSpecs[i] = spec
 	}

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -86,51 +86,72 @@ func parseSpec(specFile string, conceptDictionary *gauge.ConceptDictionary, spec
 	parseResultChan <- parseResult
 }
 
-func addSpecsToMap(specs []*gauge.Specification, specsMap map[string]*gauge.Specification) {
-	for _, spec := range specs {
-		if _, ok := specsMap[spec.FileName]; ok {
-			specsMap[spec.FileName].Scenarios = append(specsMap[spec.FileName].Scenarios, spec.Scenarios...)
-			for _, sce := range spec.Scenarios {
-				specsMap[spec.FileName].Items = append(specsMap[spec.FileName].Items, sce)
-			}
-			continue
-		}
-		specsMap[spec.FileName] = spec
-	}
+type specFile struct {
+	filePath string
+	indices  []int
 }
 
 // parseSpecsInDirs parses all the specs in list of dirs given.
 // It also merges the scenarios belonging to same spec which are passed as different arguments in `specDirs`
 func parseSpecsInDirs(conceptDictionary *gauge.ConceptDictionary, specDirs []string, buildErrors *gauge.BuildErrors) ([]*gauge.Specification, bool) {
-	specsMap := make(map[string]*gauge.Specification)
 	passed := true
-	var givenSpecs []*gauge.Specification
-	for _, specSource := range specDirs {
-		var specs []*gauge.Specification
-		var specParseResults []*ParseResult
-		if isIndexedSpec(specSource) {
-			specs, specParseResults = getSpecWithScenarioIndex(specSource, conceptDictionary, buildErrors)
-		} else {
-			specs, specParseResults = ParseSpecFiles(util.GetSpecFiles(specSource), conceptDictionary, buildErrors)
+	givenSpecs, specFiles := getAllSpecFiles(specDirs)
+	var specs []*gauge.Specification
+	var specParseResults []*ParseResult
+	allSpecs := make([]*gauge.Specification, len(specFiles))
+	specs, specParseResults = ParseSpecFiles(givenSpecs, conceptDictionary, buildErrors)
+	passed = !HandleParseResult(specParseResults...) && passed
+	for _, spec := range specs {
+		i, _ := getIndexFor(specFiles, spec.FileName)
+		specFile := specFiles[i]
+		if len(specFile.indices) > 0 {
+			filter.FilterSpecsItems(specs, filter.NewScenarioFilterBasedOnSpan(specFile.indices))
 		}
-		passed = !HandleParseResult(specParseResults...) && passed
-		givenSpecs = append(givenSpecs, specs...)
-		addSpecsToMap(specs, specsMap)
-	}
-	var allSpecs []*gauge.Specification
-	for _, spec := range givenSpecs {
-		if _, ok := specsMap[spec.FileName]; ok {
-			allSpecs = append(allSpecs, specsMap[spec.FileName])
-			delete(specsMap, spec.FileName)
-		}
+		allSpecs[i] = spec
 	}
 	return allSpecs, !passed
 }
 
-func getSpecWithScenarioIndex(specSource string, conceptDictionary *gauge.ConceptDictionary, buildErrors *gauge.BuildErrors) ([]*gauge.Specification, []*ParseResult) {
-	specName, indexToFilter := getIndexedSpecName(specSource)
-	parsedSpecs, parseResult := ParseSpecFiles(util.GetSpecFiles(specName), conceptDictionary, buildErrors)
-	return filter.FilterSpecsItems(parsedSpecs, filter.NewScenarioFilterBasedOnSpan(indexToFilter)), parseResult
+func getAllSpecFiles(specDirs []string) (givenSpecs []string, specFiles []*specFile) {
+	for _, specSource := range specDirs {
+		if isIndexedSpec(specSource) {
+			var specName string
+			specName, index := getIndexedSpecName(specSource)
+			files := util.GetSpecFiles(specName)
+			specificationFile, created := addSpecFile(&specFiles, files[0])
+			if created || len(specificationFile.indices) > 0 {
+				specificationFile.indices = append(specificationFile.indices, index)
+			}
+			givenSpecs = append(givenSpecs, files[0])
+		} else {
+			files := util.GetSpecFiles(specSource)
+			for _, file := range files {
+				specificationFile, _ := addSpecFile(&specFiles, file)
+				specificationFile.indices = specificationFile.indices[0:0]
+			}
+			givenSpecs = append(givenSpecs, files...)
+		}
+	}
+	return
+}
+
+func addSpecFile(specFiles *[]*specFile, file string) (*specFile, bool) {
+	i, exists := getIndexFor(*specFiles, file)
+	if !exists {
+		specificationFile := &specFile{filePath: file}
+		*specFiles = append(*specFiles, specificationFile)
+		return specificationFile, true
+	}
+	return (*specFiles)[i], false
+}
+
+func getIndexFor(files []*specFile, file string) (int, bool) {
+	for index, f := range files {
+		if f.filePath == file {
+			return index, true
+		}
+	}
+	return -1, false
 }
 
 func isIndexedSpec(specSource string) bool {

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -124,11 +124,21 @@ func (s *MySuite) TestCreateStepValueFromStepWithSpecialParams(c *C) {
 	c.Assert(stepValue.ParameterizedStepValue, Equals, "a step with <hello>, <file:user.txt> and <table>")
 }
 
-func (s *MySuite) TestSpecsFormArgsForMultipleIndexedArgsForOneSpec(c *C) {
+func (s *MySuite) TestSpecsFromArgsForMultipleIndexedArgsForOneSpec(c *C) {
 	specs, _ := parseSpecsInDirs(gauge.NewConceptDictionary(), []string{filepath.Join("testdata", "sample.spec:3"), filepath.Join("testdata", "sample.spec:6")}, gauge.NewBuildErrors())
 
 	c.Assert(len(specs), Equals, 1)
 	c.Assert(len(specs[0].Scenarios), Equals, 2)
+}
+
+func (s *MySuite) TestSpecsFromArgsForIndexedArgsForMultipleSpecs(c *C) {
+	sampleSpec := filepath.Join("testdata", "sample.spec")
+	sample2Spec := filepath.Join("testdata", "sample2.spec")
+	specs, _ := parseSpecsInDirs(gauge.NewConceptDictionary(), []string{sample2Spec, sampleSpec, sample2Spec + ":6"}, gauge.NewBuildErrors())
+
+	c.Assert(len(specs), Equals, 2)
+	c.Assert(len(specs[0].Scenarios), Equals, 2)
+	c.Assert(len(specs[1].Scenarios), Equals, 2)
 }
 
 func (s *MySuite) TestSpecsFromArgsMaintainsOrderOfSpecsPassed(c *C) {


### PR DESCRIPTION
- Collecting all files before parsing specs.
- De-duplication of specs is happens while collection of specs.
- Scenario indexes are stored. After parsing if there are indexed spec files, the scenarios are filtered.