### PR TITLE
LSP Code completion should handle spaces

### DIFF
--- a/api/lang/completion.go
+++ b/api/lang/completion.go
@@ -51,24 +51,32 @@ func completion(req *jsonrpc2.Request) (interface{}, error) {
 		return nil, err
 	}
 	list := completionList{IsIncomplete: false, Items: []completionItem{}}
+	prefix := ""
+	if params.Position.Character > 0 && files[params.TextDocument.URI][params.Position.Line][params.Position.Character-1] == 42 {
+		prefix = " "
+	}
 	for _, c := range provider.Concepts() {
+		cText := prefix + addPlaceHolders(c.StepValue.StepValue, c.StepValue.Parameters)
 		list.Items = append(list.Items, completionItem{
 			CompletionItem: lsp.CompletionItem{
-				Label:    c.StepValue.ParameterizedStepValue,
-				Detail:   "Concept",
-				Kind:     lsp.CIKFunction,
-				TextEdit: lsp.TextEdit{Range: lsp.Range{Start: params.Position, End: params.Position}, NewText: addPlaceHolders(c.StepValue.StepValue, c.StepValue.Parameters)},
+				Label:      c.StepValue.ParameterizedStepValue,
+				Detail:     "Concept",
+				Kind:       lsp.CIKFunction,
+				TextEdit:   lsp.TextEdit{Range: lsp.Range{Start: params.Position, End: params.Position}, NewText: cText},
+				FilterText: cText,
 			},
 			InsertTextFormat: snippet,
 		})
 	}
 	for _, s := range provider.Steps() {
+		cText := prefix + addPlaceHolders(s.StepValue, s.Args)
 		list.Items = append(list.Items, completionItem{
 			CompletionItem: lsp.CompletionItem{
-				Label:    s.ParameterizedStepValue,
-				Detail:   "Step",
-				Kind:     lsp.CIKFunction,
-				TextEdit: lsp.TextEdit{Range: lsp.Range{Start: params.Position, End: params.Position}, NewText: addPlaceHolders(s.StepValue, s.Args)},
+				Label:      s.ParameterizedStepValue,
+				Detail:     "Step",
+				Kind:       lsp.CIKFunction,
+				TextEdit:   lsp.TextEdit{Range: lsp.Range{Start: params.Position, End: params.Position}, NewText: cText},
+				FilterText: cText,
 			},
 			InsertTextFormat: snippet,
 		})

--- a/api/lang/completion.go
+++ b/api/lang/completion.go
@@ -56,12 +56,12 @@ func completion(req *jsonrpc2.Request) (interface{}, error) {
 	list := completionList{IsIncomplete: false, Items: []completionItem{}}
 	prefix := getPrefix(params)
 	for _, c := range provider.Concepts() {
-		cText := prefix + addPlaceHolders(c.StepValue.StepValue, c.StepValue.Parameters)
-		list.Items = append(list.Items, newCompletionItem(c.StepValue.ParameterizedStepValue, cText, concept, params.Position))
+		cText := addPlaceHolders(c.StepValue.StepValue, c.StepValue.Parameters)
+		list.Items = append(list.Items, newCompletionItem(c.StepValue.ParameterizedStepValue, cText, prefix, concept, params.Position))
 	}
 	for _, s := range provider.Steps() {
-		cText := prefix + addPlaceHolders(s.StepValue, s.Args)
-		list.Items = append(list.Items, newCompletionItem(s.ParameterizedStepValue, cText, step, params.Position))
+		cText := addPlaceHolders(s.StepValue, s.Args)
+		list.Items = append(list.Items, newCompletionItem(s.ParameterizedStepValue, cText, prefix, step, params.Position))
 	}
 	return list, nil
 }
@@ -81,14 +81,14 @@ func resolveCompletion(req *jsonrpc2.Request) (interface{}, error) {
 	return params, nil
 }
 
-func newCompletionItem(stepText, text, kind string, p lsp.Position) completionItem {
+func newCompletionItem(stepText, text, prefix, kind string, p lsp.Position) completionItem {
 	return completionItem{
 		CompletionItem: lsp.CompletionItem{
 			Label:      stepText,
 			Detail:     kind,
 			Kind:       lsp.CIKFunction,
-			TextEdit:   lsp.TextEdit{Range: lsp.Range{Start: p, End: p}, NewText: text},
-			FilterText: text,
+			TextEdit:   lsp.TextEdit{Range: lsp.Range{Start: p, End: p}, NewText: prefix + text},
+			FilterText: prefix + stepText,
 		},
 		InsertTextFormat: snippet,
 	}

--- a/api/lang/completion_test.go
+++ b/api/lang/completion_test.go
@@ -87,19 +87,21 @@ func TestCompletion(t *testing.T) {
 	want := completionList{IsIncomplete: false, Items: []completionItem{
 		{
 			CompletionItem: lsp.CompletionItem{
-				Label:    "concept1",
-				Detail:   "Concept",
-				Kind:     lsp.CIKFunction,
-				TextEdit: lsp.TextEdit{Range: lsp.Range{}, NewText: `concept1`},
+				Label:      "concept1",
+				Detail:     "Concept",
+				Kind:       lsp.CIKFunction,
+				TextEdit:   lsp.TextEdit{Range: lsp.Range{}, NewText: `concept1`},
+				FilterText: `concept1`,
 			},
 			InsertTextFormat: snippet,
 		},
 		{
 			CompletionItem: lsp.CompletionItem{
-				Label:    "Say <hello> to <gauge>",
-				Detail:   "Step",
-				Kind:     lsp.CIKFunction,
-				TextEdit: lsp.TextEdit{Range: lsp.Range{}, NewText: `Say "${1:hello}" to "${0:gauge}"`},
+				Label:      "Say <hello> to <gauge>",
+				Detail:     "Step",
+				Kind:       lsp.CIKFunction,
+				TextEdit:   lsp.TextEdit{Range: lsp.Range{}, NewText: `Say "${1:hello}" to "${0:gauge}"`},
+				FilterText: `Say "${1:hello}" to "${0:gauge}"`,
 			},
 			InsertTextFormat: snippet,
 		},

--- a/api/lang/completion_test.go
+++ b/api/lang/completion_test.go
@@ -99,7 +99,7 @@ func TestCompletion(t *testing.T) {
 				Detail:     "Step",
 				Kind:       lsp.CIKFunction,
 				TextEdit:   lsp.TextEdit{Range: lsp.Range{}, NewText: `Say "${1:hello}" to "${0:gauge}"`},
-				FilterText: `Say "${1:hello}" to "${0:gauge}"`,
+				FilterText: "Say <hello> to <gauge>",
 			},
 			InsertTextFormat: snippet,
 		},

--- a/api/lang/completion_test.go
+++ b/api/lang/completion_test.go
@@ -22,8 +22,6 @@ import (
 	"reflect"
 	"testing"
 
-	"fmt"
-
 	"github.com/getgauge/gauge/gauge"
 	gm "github.com/getgauge/gauge/gauge_messages"
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
@@ -118,10 +116,6 @@ func TestCompletion(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(got, want) {
-		a, _ := json.Marshal(got)
-		b, _ := json.Marshal(want)
-		fmt.Println(string(a))
-		fmt.Println(string(b))
 		t.Errorf("Autocomplete request failed, got: `%s`, want: `%s`", got, want)
 	}
 }
@@ -156,5 +150,40 @@ func TestCompletionResolveWithError(t *testing.T) {
 
 	if err == nil {
 		t.Error("Expected error != nil in Completion, got nil")
+	}
+}
+
+func TestGetPrefix(t *testing.T) {
+	want := " "
+	f = &files{cache: make(map[string][]string)}
+	f.add("uri", "line1\n*")
+	params := lsp.TextDocumentPositionParams{TextDocument: lsp.TextDocumentIdentifier{URI: "uri"}, Position: lsp.Position{Line: 1, Character: 1}}
+	got := getPrefix(params)
+
+	if got != want {
+		t.Errorf("GetPrefix failed for autocomplete, want: `%s`, got: `%s`", want, got)
+	}
+}
+
+func TestGetPrefixWithSpace(t *testing.T) {
+	want := ""
+	f = &files{cache: make(map[string][]string)}
+	f.add("uri", "* ")
+	params := lsp.TextDocumentPositionParams{TextDocument: lsp.TextDocumentIdentifier{URI: "uri"}, Position: lsp.Position{Line: 0, Character: 2}}
+	got := getPrefix(params)
+
+	if got != want {
+		t.Errorf("GetPrefix failed for autocomplete, want: `%s`, got: `%s`", want, got)
+	}
+}
+
+func TestGetPrefixWithNoCharsInLine(t *testing.T) {
+	want := ""
+	f = &files{cache: make(map[string][]string)}
+	params := lsp.TextDocumentPositionParams{TextDocument: lsp.TextDocumentIdentifier{URI: "uri"}, Position: lsp.Position{Line: 1, Character: 0}}
+	got := getPrefix(params)
+
+	if got != want {
+		t.Errorf("GetPrefix failed for autocomplete, want: `%s`, got: `%s`", want, got)
 	}
 }

--- a/api/lang/file.go
+++ b/api/lang/file.go
@@ -1,0 +1,53 @@
+// Copyright 2015 ThoughtWorks, Inc.
+
+// This file is part of Gauge.
+
+// Gauge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Gauge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Gauge.  If not, see <http://www.gnu.org/licenses/>.
+
+package lang
+
+import (
+	"encoding/json"
+
+	"strings"
+
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+var files = make(map[string][]string)
+
+func openFile(req *jsonrpc2.Request) {
+	var params lsp.DidOpenTextDocumentParams
+	if err := json.Unmarshal(*req.Params, &params); err != nil {
+		return
+	}
+	files[params.TextDocument.URI] = strings.Split(params.TextDocument.Text, "\n")
+}
+
+func closeFile(req *jsonrpc2.Request) {
+	var params lsp.DidCloseTextDocumentParams
+	if err := json.Unmarshal(*req.Params, &params); err != nil {
+		return
+	}
+	delete(files, params.TextDocument.URI)
+}
+
+func changeFile(req *jsonrpc2.Request) {
+	var params lsp.DidChangeTextDocumentParams
+	if err := json.Unmarshal(*req.Params, &params); err != nil {
+		return
+	}
+	files[params.TextDocument.URI] = strings.Split(params.ContentChanges[0].Text, "\n")
+}

--- a/api/lang/server.go
+++ b/api/lang/server.go
@@ -60,17 +60,7 @@ func newHandler() jsonrpc2.Handler {
 }
 
 func (h lspHandler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
-	if isFileSystemRequest(req.Method) {
-		return
-	}
 	go h.Handler.Handle(ctx, conn, req)
-}
-
-func isFileSystemRequest(method string) bool {
-	return method == "textDocument/didOpen" ||
-		method == "textDocument/didChange" ||
-		method == "textDocument/didClose" ||
-		method == "textDocument/didSave"
 }
 
 func (h *LangHandler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (interface{}, error) {
@@ -98,6 +88,15 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 		return nil, nil
 
 	case "$/cancelRequest":
+		return nil, nil
+	case "textDocument/didOpen":
+		openFile(req)
+		return nil, nil
+	case "textDocument/didClose":
+		closeFile(req)
+		return nil, nil
+	case "textDocument/didChange":
+		changeFile(req)
 		return nil, nil
 	case "textDocument/completion":
 		return completion(req)


### PR DESCRIPTION
Fixing bugs on #718 
- Completion item list will give parameters with spaces if given user invokes autocomplete with only `*`. If the autocomplete is invoked with `*` and a space, the list will not have a space at start.
- The autocomplete will automatically add a space after `*` if user has not given one already.
- Added a document text cache for all open files.