### PR TITLE
improvements on LSP support for code completion

### DIFF
--- a/api/infoGatherer/specDetails.go
+++ b/api/infoGatherer/specDetails.go
@@ -372,11 +372,17 @@ func (s *SpecInfoGatherer) GetAvailableSpecDetails(specs []string) []*SpecDetail
 
 // Steps returns the list of all the steps in the gauge project
 func (s *SpecInfoGatherer) Steps() []*gauge.StepValue {
-	var steps []*gauge.StepValue
 	s.stepsCache.mutex.RLock()
 	defer s.stepsCache.mutex.RUnlock()
+	sValues := make(map[string]*gauge.StepValue)
 	for _, stepValues := range s.stepsCache.stepValues {
-		steps = append(steps, stepValues...)
+		for _, sv := range stepValues {
+			sValues[sv.StepValue] = sv
+		}
+	}
+	var steps []*gauge.StepValue
+	for _, sv := range sValues {
+		steps = append(steps, sv)
 	}
 	return steps
 }

--- a/api/infoGatherer/specDetails_test.go
+++ b/api/infoGatherer/specDetails_test.go
@@ -246,7 +246,7 @@ func (s *MySuite) TestGetAvailableStepsShouldFilterDuplicates(c *C) {
 	}
 }
 
-func hasStep(stepValues []*gauge.StepValue, step string) bool{
+func hasStep(stepValues []*gauge.StepValue, step string) bool {
 	for _, value := range stepValues {
 		if value.StepValue == step {
 			return true

--- a/api/infoGatherer/specDetails_test.go
+++ b/api/infoGatherer/specDetails_test.go
@@ -224,8 +224,12 @@ func (s *MySuite) TestGetAvailableSteps(c *C) {
 
 	stepValues = specInfoGatherer.Steps()
 	c.Assert(len(stepValues), Equals, 2)
-	c.Assert(stepValues[0].StepValue, Equals, "say hello")
-	c.Assert(stepValues[1].StepValue, Equals, "say {} to me")
+	if !hasStep(stepValues, "say hello") {
+		c.Fatalf("Step value not found %s", "say hello")
+	}
+	if !hasStep(stepValues, "say {} to me") {
+		c.Fatalf("Step value not found %s", "say {} to me")
+	}
 }
 
 func (s *MySuite) TestGetAvailableStepsShouldFilterDuplicates(c *C) {

--- a/api/lang/completion.go
+++ b/api/lang/completion.go
@@ -46,15 +46,14 @@ type completionList struct {
 	Items        []completionItem `json:"items"`
 }
 
-func isStepCompletion(params lsp.TextDocumentPositionParams) bool {
-	line := getLine(params.TextDocument.URI, params.Position.Line)
-	if params.Position.Character == 0 {
+func isStepCompletion(line string, character int) bool {
+	if character == 0 {
 		return false
 	}
 	if !strings.HasPrefix(strings.TrimSpace(line), "*") {
 		return false
 	}
-	return !inParameterContext(line, params.Position.Character)
+	return !inParameterContext(line, character)
 }
 
 func inParameterContext(line string, charPos int) bool {
@@ -87,7 +86,8 @@ func completion(req *jsonrpc2.Request) (interface{}, error) {
 	if err := json.Unmarshal(*req.Params, &params); err != nil {
 		return nil, err
 	}
-	if !isStepCompletion(params) {
+	line := getLine(params.TextDocument.URI, params.Position.Line)
+	if !isStepCompletion(line, params.Position.Character) {
 		return nil, nil
 	}
 	list := completionList{IsIncomplete: false, Items: []completionItem{}}

--- a/api/lang/completion.go
+++ b/api/lang/completion.go
@@ -63,11 +63,11 @@ func completion(req *jsonrpc2.Request) (interface{}, error) {
 	startPos, endPos := getEditPosition(line, params.Position)
 	prefix := getPrefix(pLine)
 	var givenArgs []gauge.StepArg
-		var err error
-		givenArgs, err = getStepArgs(strings.TrimSpace(pLine))
-		if err != nil {
-			return nil, err
-		}
+	var err error
+	givenArgs, err = getStepArgs(strings.TrimSpace(pLine))
+	if err != nil {
+		return nil, err
+	}
 	for _, c := range provider.Concepts() {
 		fText := getFilterText(c.StepValue.StepValue, c.StepValue.Parameters, givenArgs)
 		cText := prefix + addPlaceHolders(c.StepValue.StepValue, c.StepValue.Parameters)

--- a/api/lang/completion.go
+++ b/api/lang/completion.go
@@ -64,7 +64,7 @@ func completion(req *jsonrpc2.Request) (interface{}, error) {
 	var givenArgs []gauge.StepArg
 	if startPos.Character != endPos.Character {
 		var err error
-		givenArgs, err = getStepArgs(line[:params.Position.Character])
+		givenArgs, err = getStepArgs(strings.TrimSpace(line[:params.Position.Character]))
 		if err != nil {
 			return nil, err
 		}
@@ -99,6 +99,7 @@ func getStepArgs(line string) ([]gauge.StepArg, error) {
 	return givenArgs, nil
 
 }
+
 func isStepCompletion(line string, character int) bool {
 	if character == 0 {
 		return false
@@ -157,7 +158,7 @@ func getFilterText(text string, params []string, givenArgs []gauge.StepArg) stri
 
 func getEditPosition(line string, cursorPos lsp.Position) (lsp.Position, lsp.Position) {
 	start := 1
-	loc := regexp.MustCompile(`^\*(\s*)`).FindIndex([]byte(line))
+	loc := regexp.MustCompile(`^\s*\*(\s*)`).FindIndex([]byte(line))
 	if loc != nil {
 		start = loc[1]
 	}

--- a/api/lang/completion.go
+++ b/api/lang/completion.go
@@ -22,6 +22,10 @@ import (
 	"fmt"
 	"strings"
 
+	"regexp"
+
+	"github.com/getgauge/gauge/gauge"
+	"github.com/getgauge/gauge/parser"
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
 	"github.com/sourcegraph/jsonrpc2"
 )
@@ -29,11 +33,10 @@ import (
 type insertTextFormat int
 
 const (
-	text     insertTextFormat = 1
-	snippet  insertTextFormat = 2
-	asterisk byte             = 42
-	concept                   = "Concept"
-	step                      = "Step"
+	text    insertTextFormat = 1
+	snippet insertTextFormat = 2
+	concept                  = "Concept"
+	step                     = "Step"
 )
 
 type completionItem struct {
@@ -46,6 +49,56 @@ type completionList struct {
 	Items        []completionItem `json:"items"`
 }
 
+func completion(req *jsonrpc2.Request) (interface{}, error) {
+	var params lsp.TextDocumentPositionParams
+	if err := json.Unmarshal(*req.Params, &params); err != nil {
+		return nil, err
+	}
+	line := getLine(params.TextDocument.URI, params.Position.Line)
+	if !isStepCompletion(line, params.Position.Character) {
+		return nil, nil
+	}
+	list := completionList{IsIncomplete: false, Items: []completionItem{}}
+	startPos, endPos := getEditPosition(line, params.Position)
+	prefix := getPrefix(line)
+	var givenArgs []gauge.StepArg
+	if startPos.Character != endPos.Character {
+		var err error
+		givenArgs, err = getStepArgs(line[:params.Position.Character])
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, c := range provider.Concepts() {
+		fText := getFilterText(c.StepValue.StepValue, c.StepValue.Parameters, givenArgs)
+		cText := prefix + addPlaceHolders(c.StepValue.StepValue, c.StepValue.Parameters)
+		list.Items = append(list.Items, newCompletionItem(c.StepValue.ParameterizedStepValue, cText, concept, fText, startPos, endPos))
+	}
+	for _, s := range provider.Steps() {
+		fText := getFilterText(s.StepValue, s.Args, givenArgs)
+		cText := prefix + addPlaceHolders(s.StepValue, s.Args)
+		list.Items = append(list.Items, newCompletionItem(s.ParameterizedStepValue, cText, step, fText, startPos, endPos))
+	}
+	return list, nil
+}
+
+func getStepArgs(line string) ([]gauge.StepArg, error) {
+	var givenArgs []gauge.StepArg
+	if line != "" {
+		specParser := new(parser.SpecParser)
+		tokens, errs := specParser.GenerateTokens(line, "")
+		if len(errs) > 0 {
+			return nil, fmt.Errorf("Unable to parse text entered")
+		}
+		var err error
+		givenArgs, err = parser.ExtractStepArgsFromToken(tokens[0])
+		if err != nil {
+			return nil, fmt.Errorf("Unable to parse text entered")
+		}
+	}
+	return givenArgs, nil
+
+}
 func isStepCompletion(line string, character int) bool {
 	if character == 0 {
 		return false
@@ -57,11 +110,15 @@ func isStepCompletion(line string, character int) bool {
 }
 
 func inParameterContext(line string, charPos int) bool {
-	lineAfterCharPos := strings.SplitAfter(line[:charPos], "*")
+	pl := line
+	if len(line) > charPos {
+		pl = line[:charPos]
+	}
+	lineAfterCharPos := strings.SplitAfter(pl, "*")
 	if len(lineAfterCharPos) == 1 {
 		return false
 	}
-	l := strings.TrimPrefix(strings.SplitAfter(line[:charPos], "*")[1], " ")
+	l := strings.TrimPrefix(strings.SplitAfter(pl, "*")[1], " ")
 	var stack string
 	for _, value := range l {
 		if string(value) == "<" {
@@ -81,33 +138,44 @@ func inParameterContext(line string, charPos int) bool {
 	return len(stack) != 0
 }
 
-func completion(req *jsonrpc2.Request) (interface{}, error) {
-	var params lsp.TextDocumentPositionParams
-	if err := json.Unmarshal(*req.Params, &params); err != nil {
-		return nil, err
+func getFilterText(text string, params []string, givenArgs []gauge.StepArg) string {
+	if len(params) > 0 {
+		for i, p := range params {
+			if len(givenArgs) > i {
+				if givenArgs[i].ArgType == gauge.Static {
+					text = strings.Replace(text, "{}", fmt.Sprintf("\"%s\"", givenArgs[i].ArgValue()), 1)
+				} else {
+					text = strings.Replace(text, "{}", fmt.Sprintf("<%s>", givenArgs[i].ArgValue()), 1)
+				}
+			} else {
+				text = strings.Replace(text, "{}", fmt.Sprintf("<%s>", p), 1)
+			}
+		}
 	}
-	line := getLine(params.TextDocument.URI, params.Position.Line)
-	if !isStepCompletion(line, params.Position.Character) {
-		return nil, nil
-	}
-	list := completionList{IsIncomplete: false, Items: []completionItem{}}
-	prefix := getPrefix(params)
-	for _, c := range provider.Concepts() {
-		cText := addPlaceHolders(c.StepValue.StepValue, c.StepValue.Parameters)
-		list.Items = append(list.Items, newCompletionItem(c.StepValue.ParameterizedStepValue, cText, prefix, concept, params.Position))
-	}
-	for _, s := range provider.Steps() {
-		cText := addPlaceHolders(s.StepValue, s.Args)
-		list.Items = append(list.Items, newCompletionItem(s.ParameterizedStepValue, cText, prefix, step, params.Position))
-	}
-	return list, nil
+	return text
 }
 
-func getPrefix(p lsp.TextDocumentPositionParams) string {
-	if p.Position.Character > 0 && getChar(p.TextDocument.URI, p.Position.Line, p.Position.Character-1) == asterisk {
-		return " "
+func getEditPosition(line string, cursorPos lsp.Position) (lsp.Position, lsp.Position) {
+	start := 1
+	loc := regexp.MustCompile(`^\*(\s*)`).FindIndex([]byte(line))
+	if loc != nil {
+		start = loc[1]
 	}
-	return ""
+	end := len(line)
+	if end < 2 {
+		end = 1
+	}
+	if end < cursorPos.Character {
+		end = cursorPos.Character
+	}
+	return lsp.Position{Line: cursorPos.Line, Character: start}, lsp.Position{Line: cursorPos.Line, Character: end}
+}
+
+func getPrefix(line string) string {
+	if strings.HasPrefix(line, "* ") {
+		return ""
+	}
+	return " "
 }
 
 func resolveCompletion(req *jsonrpc2.Request) (interface{}, error) {
@@ -118,14 +186,14 @@ func resolveCompletion(req *jsonrpc2.Request) (interface{}, error) {
 	return params, nil
 }
 
-func newCompletionItem(stepText, text, prefix, kind string, p lsp.Position) completionItem {
+func newCompletionItem(stepText, text, kind, fText string, startPos, endPos lsp.Position) completionItem {
 	return completionItem{
 		CompletionItem: lsp.CompletionItem{
 			Label:      stepText,
 			Detail:     kind,
 			Kind:       lsp.CIKFunction,
-			TextEdit:   lsp.TextEdit{Range: lsp.Range{Start: p, End: p}, NewText: prefix + text},
-			FilterText: prefix + stepText,
+			TextEdit:   lsp.TextEdit{Range: lsp.Range{Start: startPos, End: endPos}, NewText: text},
+			FilterText: fText,
 		},
 		InsertTextFormat: snippet,
 	}

--- a/api/lang/completion_test.go
+++ b/api/lang/completion_test.go
@@ -409,3 +409,65 @@ func TestGetFilterTextWithLesserNumberOfStepArgsGiven(t *testing.T) {
 		t.Errorf("The parameters are not replaced correctly")
 	}
 }
+
+var testEditPosition = []struct {
+	input     string
+	cursorPos lsp.Position
+	wantStart lsp.Position
+	wantEnd   lsp.Position
+}{
+	{
+		input:     "*",
+		cursorPos: lsp.Position{Line: 0, Character: 1},
+		wantStart: lsp.Position{Line: 0, Character: 1},
+		wantEnd:   lsp.Position{Line: 0, Character: 1},
+	},
+	{
+		input:     "* ",
+		cursorPos: lsp.Position{Line: 0, Character: 1},
+		wantStart: lsp.Position{Line: 0, Character: 1},
+		wantEnd:   lsp.Position{Line: 0, Character: 2},
+	},
+	{
+		input:     "* Step",
+		cursorPos: lsp.Position{Line: 10, Character: 1},
+		wantStart: lsp.Position{Line: 10, Character: 1},
+		wantEnd:   lsp.Position{Line: 10, Character: 6},
+	},
+	{
+		input:     "* Step",
+		cursorPos: lsp.Position{Line: 0, Character: 2},
+		wantStart: lsp.Position{Line: 0, Character: 2},
+		wantEnd:   lsp.Position{Line: 0, Character: 6},
+	},
+	{
+		input:     "* Step",
+		cursorPos: lsp.Position{Line: 0, Character: 4},
+		wantStart: lsp.Position{Line: 0, Character: 2},
+		wantEnd:   lsp.Position{Line: 0, Character: 6},
+	},
+	{
+		input:     "    * Step",
+		cursorPos: lsp.Position{Line: 0, Character: 7},
+		wantStart: lsp.Position{Line: 0, Character: 6},
+		wantEnd:   lsp.Position{Line: 0, Character: 10},
+	},
+	{
+		input:     " * Step ",
+		cursorPos: lsp.Position{Line: 0, Character: 10},
+		wantStart: lsp.Position{Line: 0, Character: 3},
+		wantEnd:   lsp.Position{Line: 0, Character: 10},
+	},
+}
+
+func TestGetEditPosition(t *testing.T) {
+	for _, test := range testEditPosition {
+		gotStart, gotEnd := getEditPosition(test.input, test.cursorPos)
+		if gotStart.Line != test.wantStart.Line || gotStart.Character != test.wantStart.Character {
+			t.Errorf(`Incorrect Edit Start Position got: %+v , want : %+v, input : "%s"`, gotStart, test.wantStart, test.input)
+		}
+		if gotEnd.Line != test.wantEnd.Line || gotEnd.Character != test.wantEnd.Character {
+			t.Errorf(`Incorrect Edit End Position got: %+v , want : %+v, input : "%s"`, gotEnd, test.wantEnd, test.input)
+		}
+	}
+}

--- a/api/lang/completion_test.go
+++ b/api/lang/completion_test.go
@@ -192,44 +192,25 @@ func TestGetPrefixWithNoCharsInLine(t *testing.T) {
 }
 
 func TestIsInStepCompletionAtStartOfLine(t *testing.T) {
-	f = &files{cache: make(map[string][]string)}
-	f.add("uri", `* `)
-	position := lsp.Position{Line: 0, Character: 1}
-	params := lsp.TextDocumentPositionParams{TextDocument: lsp.TextDocumentIdentifier{URI: "uri"}, Position: position}
-	if !isStepCompletion(params) {
+	if !isStepCompletion("* ", 1) {
 		t.Errorf("isStepCompletion not recognizing step context")
 	}
 }
 
 func TestIsInStepCompletionAtEndOfLine(t *testing.T) {
-	f = &files{cache: make(map[string][]string)}
-	f.add("uri", `* Step without params`)
-	position := lsp.Position{Line: 0, Character: 21}
-	params := lsp.TextDocumentPositionParams{TextDocument: lsp.TextDocumentIdentifier{URI: "uri"}, Position: position}
-	if !isStepCompletion(params) {
+	if !isStepCompletion("* Step without params", 21) {
 		t.Errorf("isStepCompletion not recognizing step context")
 	}
 }
 
 func TestIsInStepCompletionWithParams(t *testing.T) {
-	f = &files{cache: make(map[string][]string)}
-	f.add("uri", `* Step with "static" and <dynamic> params`)
-
-	position := lsp.Position{Line: 0, Character: 13}
-	params := lsp.TextDocumentPositionParams{TextDocument: lsp.TextDocumentIdentifier{URI: "uri"}, Position: position}
-	if isStepCompletion(params) {
+	if isStepCompletion(`* Step with "static" and <dynamic> params`, 13) {
 		t.Errorf("isStepCompletion not recognizing step context")
 	}
-
-	position = lsp.Position{Line: 0, Character: 24}
-	params = lsp.TextDocumentPositionParams{TextDocument: lsp.TextDocumentIdentifier{URI: "uri"}, Position: position}
-	if !isStepCompletion(params) {
+	if !isStepCompletion(`* Step with "static" and <dynamic> params`, 24) {
 		t.Errorf("isStepCompletion not recognizing step context")
 	}
-
-	position = lsp.Position{Line: 0, Character: 28}
-	params = lsp.TextDocumentPositionParams{TextDocument: lsp.TextDocumentIdentifier{URI: "uri"}, Position: position}
-	if isStepCompletion(params) {
+	if isStepCompletion(`* Step with "static" and <dynamic> params`, 28) {
 		t.Errorf("isStepCompletion not recognizing step context")
 	}
 }

--- a/api/lang/completion_test.go
+++ b/api/lang/completion_test.go
@@ -83,8 +83,8 @@ func (p *dummyCompletionProvider) Concepts() []*gm.ConceptInfo {
 
 func TestCompletion(t *testing.T) {
 	f = &files{cache: make(map[string][]string)}
-	f.add("uri", "* ")
-	position := lsp.Position{Line: 0, Character: 2}
+	f.add("uri", " * ")
+	position := lsp.Position{Line: 0, Character: 3}
 	want := completionList{IsIncomplete: false, Items: []completionItem{
 		{
 			CompletionItem: lsp.CompletionItem{

--- a/api/lang/file.go
+++ b/api/lang/file.go
@@ -55,6 +55,12 @@ func (f *files) char(uri string, line, char int) (asciiCode byte) {
 	return f.cache[uri][line][char]
 }
 
+func (f *files) line(uri string, lineNo int) string {
+	f.Lock()
+	defer f.Unlock()
+	return f.cache[uri][lineNo]
+}
+
 var f = &files{cache: make(map[string][]string)}
 
 func openFile(req *jsonrpc2.Request) {
@@ -84,4 +90,8 @@ func changeFile(req *jsonrpc2.Request) {
 
 func getChar(uri string, line, char int) (asciiCode byte) {
 	return f.char(uri, line, char)
+}
+
+func getLine(uri string, line int) string {
+	return f.line(uri, line)
 }

--- a/gauge/arg.go
+++ b/gauge/arg.go
@@ -125,3 +125,15 @@ type StepArg struct {
 func (stepArg *StepArg) String() string {
 	return fmt.Sprintf("{Name: %s,value %s,argType %s,table %v}", stepArg.Name, stepArg.Value, string(stepArg.ArgType), stepArg.Table)
 }
+
+func (stepArg *StepArg) ArgValue() string {
+	switch stepArg.ArgType {
+	case Static, Dynamic:
+		return stepArg.Value
+	case TableArg:
+		return "table"
+	case SpecialString, SpecialTable:
+		return stepArg.Name
+	}
+	return ""
+}

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -196,14 +196,7 @@ func CreateStepValue(step *gauge.Step) gauge.StepValue {
 	stepValue := gauge.StepValue{StepValue: step.Value}
 	args := make([]string, 0)
 	for _, arg := range step.Args {
-		switch arg.ArgType {
-		case gauge.Static, gauge.Dynamic:
-			args = append(args, arg.Value)
-		case gauge.TableArg:
-			args = append(args, "table")
-		case gauge.SpecialString, gauge.SpecialTable:
-			args = append(args, arg.Name)
-		}
+		args = append(args, arg.ArgValue())
 	}
 	stepValue.Args = args
 	stepValue.ParameterizedStepValue = getParameterizeStepValue(stepValue.StepValue, args)

--- a/parser/specparser.go
+++ b/parser/specparser.go
@@ -607,6 +607,22 @@ func CreateStepUsingLookup(stepToken *Token, lookup *gauge.ArgLookup, specFileNa
 	return step, &ParseResult{Warnings: warnings}
 }
 
+func ExtractStepArgsFromToken(stepToken *Token) ([]gauge.StepArg, error) {
+	_, argsType := extractStepValueAndParameterTypes(stepToken.Value)
+	if argsType != nil && len(argsType) != len(stepToken.Args) {
+		return nil, fmt.Errorf("Step text should not have '{static}' or '{dynamic}' or '{special}'")
+	}
+	var args []gauge.StepArg
+	for i, argType := range argsType {
+		if gauge.ArgType(argType) == gauge.Static {
+			args = append(args, gauge.StepArg{ArgType: gauge.Static, Value: stepToken.Args[i]})
+		} else {
+			args = append(args, gauge.StepArg{ArgType: gauge.Dynamic, Value: stepToken.Args[i]})
+		}
+	}
+	return args, nil
+}
+
 func createConceptStep(spec *gauge.Specification, concept *gauge.Step, originalStep *gauge.Step) {
 	stepCopy := concept.GetCopy()
 	originalArgs := originalStep.Args

--- a/parser/specparser_test.go
+++ b/parser/specparser_test.go
@@ -1651,3 +1651,17 @@ Scenario Heading
 	c.Assert(parseRes.ParseErrors[2].Message, Equals, "Table header should not be blank")
 	c.Assert(parseRes.ParseErrors[3].Message, Equals, "Table header cannot have repeated column values")
 }
+
+func (s *MySuite) TestExtractStepArgsFromToken(c *C) {
+	token := &Token{Kind: gauge.StepKind, LineText: `my step with "Static" and <Dynamic> params`, Value: `my step with {static} and {dynamic} params`, Args: []string{"Static", "Dynamic"}}
+
+	args, err := ExtractStepArgsFromToken(token)
+	if err != nil {
+		c.Fatalf("Error while extracting step args : %s", err.Error())
+	}
+	c.Assert(len(args), Equals, 2)
+	c.Assert(args[0].Value, Equals, "Static")
+	c.Assert(args[0].ArgType, Equals, gauge.Static)
+	c.Assert(args[1].Value, Equals, "Dynamic")
+	c.Assert(args[1].ArgType, Equals, gauge.Dynamic)
+}


### PR DESCRIPTION
- completion shows only if the cursor is in between a step
- completion doesn't show up if cursor is in between parameters 
- duplicate steps are filtered
- completion replaces the text (after *) entered by the user.