### PR TITLE
Update issue template version command

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -21,5 +21,5 @@ Tell us what happens instead
 
 ### Gauge version
 ```
-Run gauge -v on your system and paste the results here.
+Run gauge version on your system and paste the results here.
 ```


### PR DESCRIPTION
On Gauge 0.9.1, the command in the Github issue template to get the version prints this deprecation warning:

```
$ gauge -v
[DEPRECATED] This usage will be removed soon. Run `gauge help --legacy` for more info.
Gauge version: 0.9.1
```

This replaces the deprecated `-v` flag with preferred `version` subcommand.