### PR TITLE
Lsp telemetry message

### DIFF
--- a/api/lang/server.go
+++ b/api/lang/server.go
@@ -82,6 +82,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 		return gaugeLSPCapabilities(), nil
 	case "initialized":
 		registerFileWatcher(conn, ctx)
+		notifyTelemetry(ctx, conn)
 		err := registerRunnerCapabilities(conn, ctx)
 		if err != nil {
 			logError(req, err.Error())

--- a/api/lang/telemetry.go
+++ b/api/lang/telemetry.go
@@ -1,0 +1,51 @@
+// Copyright 2018 ThoughtWorks, Inc.
+
+// This file is part of Gauge.
+
+// Gauge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Gauge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Gauge.  If not, see <http://www.gnu.org/licenses/>.
+
+package lang
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/getgauge/gauge/config"
+	"github.com/getgauge/gauge/track"
+
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+func notifyTelemetry(ctx context.Context, conn jsonrpc2.JSONRPC2) {
+	if config.TelemetryConsent() {
+		return
+	}
+	var result lsp.MessageActionItem
+	var params = lsp.ShowMessageRequestParams{
+		Type:    lsp.Info,
+		Message: track.GaugeTelemetryLSPMessage,
+		Actions: []lsp.MessageActionItem{
+			lsp.MessageActionItem{Title: "Yes"},
+			lsp.MessageActionItem{Title: "No"},
+		},
+	}
+	err := conn.Call(ctx, "window/showMessageRequest", params, &result)
+
+	if err != nil {
+		return
+	}
+	config.UpdateTelemetry(fmt.Sprintf("%t", result.Title != "No"))
+	config.RecordTelemetryConsentSet()
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -41,20 +41,10 @@ const (
 	machineReadableDefault = false
 	gaugeVersionDefault    = false
 
-	logLevelName                 = "log-level"
-	dirName                      = "dir"
-	machineReadableName          = "machine-readable"
-	gaugeVersionName             = "version"
-	gaugeTelemetryMessageHeading = `
-Telemetry
----------
-`
-	gaugeTelemetryMessage = `This installation of Gauge collects usage data in order to help us improve your experience.
-The data is anonymous and doesn't include command-line arguments.
-To turn this message off opt in or out by running 'gauge telemetry on' or 'gauge telemetry off'.
-
-Read more about Gauge telemetry at https://gauge.org/telemetry
-`
+	logLevelName        = "log-level"
+	dirName             = "dir"
+	machineReadableName = "machine-readable"
+	gaugeVersionName    = "version"
 )
 
 var (
@@ -89,11 +79,11 @@ var (
 )
 
 func notifyTelemetryIfNeeded(cmd *cobra.Command, args []string) {
-	if !config.TelemetryConsent() {
+	if !gaugeVersion && !config.TelemetryConsent() {
 		if machineReadable {
-			fmt.Printf("{\"Telemetry\": \"%s\"}\n", strings.Replace(gaugeTelemetryMessage, "\n", "", -1))
+			fmt.Printf("{\"telemetry\": \"%s\"}\n", strings.Replace(track.GaugeTelemetryMessage, "\n", "", -1))
 		} else {
-			fmt.Printf("%s\n%s\n", gaugeTelemetryMessageHeading, gaugeTelemetryMessage)
+			fmt.Printf("%s\n%s\n", track.GaugeTelemetryMessageHeading, track.GaugeTelemetryMessage)
 		}
 	}
 }

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -63,6 +63,7 @@ var (
 			}
 			api.RunInBackground(port, specs)
 		},
+		PersistentPostRun: func(cmd *cobra.Command, args []string) { /* noop */ },
 		DisableAutoGenTag: true,
 	}
 	lsp bool

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/getgauge/gauge/track"
+
 	"github.com/getgauge/gauge/plugin/pluginInfo"
 	"github.com/getgauge/gauge/version"
 	"github.com/spf13/cobra"
@@ -38,6 +40,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			printVersion()
 		},
+		PersistentPostRun: func(cmd *cobra.Command, args []string) { /* noop */ },
 		DisableAutoGenTag: true,
 	}
 )
@@ -60,11 +63,12 @@ func printJSONVersion() {
 		Version string `json:"version"`
 	}
 	type versionJSON struct {
-		Version    string        `json:"version"`
-		CommitHash string        `json:"commitHash"`
-		Plugins    []*pluginJSON `json:"plugins"`
+		Version          string        `json:"version"`
+		CommitHash       string        `json:"commitHash"`
+		Plugins          []*pluginJSON `json:"plugins"`
+		TelemetryMessage string        `json:"telemetry"`
 	}
-	gaugeVersion := versionJSON{version.FullVersion(), version.GetCommitHash(), make([]*pluginJSON, 0)}
+	gaugeVersion := versionJSON{version.FullVersion(), version.GetCommitHash(), make([]*pluginJSON, 0), track.GaugeTelemetryMessage}
 	allPluginsWithVersion, err := pluginInfo.GetAllInstalledPluginsWithVersion()
 	for _, pluginInfo := range allPluginsWithVersion {
 		gaugeVersion.Plugins = append(gaugeVersion.Plugins, &pluginJSON{pluginInfo.Name, filepath.Base(pluginInfo.Path)})

--- a/track/track.go
+++ b/track/track.go
@@ -18,10 +18,10 @@
 package track
 
 import (
-	"strconv"
 	"net/http"
 	"net/http/httputil"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"time"
 
@@ -45,6 +45,19 @@ const (
 	apiMedium     = "api"
 	ciMedium      = "CI"
 	timeout       = 1
+	// GaugeTelemetryMessageHeading is the header printed for telemetry warning
+	GaugeTelemetryMessageHeading = `
+Telemetry
+---------
+`
+	// GaugeTelemetryMessage is the message printed when user has not explicitly opted in/out
+	// of telemetry. Printed only in CLI.
+	GaugeTelemetryMessage = `This installation of Gauge collects usage data in order to help us improve your experience.
+The data is anonymous and doesn't include command-line arguments.
+To turn this message off opt in or out by running 'gauge telemetry on' or 'gauge telemetry off'.
+
+Read more about Gauge telemetry at https://gauge.org/telemetry
+`
 )
 
 var gaHTTPTransport = http.DefaultTransport

--- a/track/track.go
+++ b/track/track.go
@@ -58,6 +58,12 @@ To turn this message off opt in or out by running 'gauge telemetry on' or 'gauge
 
 Read more about Gauge telemetry at https://gauge.org/telemetry
 `
+
+	// GaugeTelemetryLSPMessage is the message printed when user has not explicitly opted in/out
+	// of telemetry. Displayed only in LSP Client.
+	GaugeTelemetryLSPMessage = `This installation of Gauge collects usage data in order to help us improve your experience.
+[Read more here](https://gauge.org/telemetry) about Gauge telemetry.
+Would you like to participate?`
 )
 
 var gaHTTPTransport = http.DefaultTransport


### PR DESCRIPTION
- do not print telemetry message for `version` and `daemon` subcommands
- prompt the user about telemetry via lsp

ref https://github.com/getgauge/gauge-vscode/issues/283