### PR TITLE
rename: no-exit-code to fail-safe

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -53,7 +53,7 @@ const (
 	rowsDefault           = ""
 	strategyDefault       = "lazy"
 	groupDefault          = -1
-	noExitCodeDefault     = false
+	failSafeDefault       = false
 
 	verboseName        = "verbose"
 	simpleConsoleName  = "simple-console"
@@ -68,7 +68,7 @@ const (
 	strategyName       = "strategy"
 	groupName          = "group"
 	streamsName        = "n"
-	noExitCodeName     = "no-exit-code"
+	failSafeName       = "fail-safe"
 )
 
 var overrideRerunFlags = []string{verboseName, simpleConsoleName, machineReadableName, dirName, logLevelName}
@@ -129,7 +129,7 @@ var (
 	strategy       string
 	streams        int
 	group          int
-	noExitCode     bool
+	failSafe       bool
 )
 
 func init() {
@@ -148,7 +148,7 @@ func init() {
 	runCmd.Flags().BoolVarP(&failed, failedName, "f", failedDefault, "Run only the scenarios failed in previous run. This cannot be used in conjunction with any other argument")
 	runCmd.Flags().BoolVarP(&repeat, repeatName, "", repeatDefault, "Repeat last run. This cannot be used in conjunction with any other argument")
 	runCmd.Flags().BoolVarP(&hideSuggestion, hideSuggestionName, "", hideSuggestionDefault, "Prints a step implementation stub for every unimplemented step")
-	runCmd.Flags().BoolVarP(&noExitCode, noExitCodeName, "", noExitCodeDefault, "Force return 0 exit code, even in case of failures.")
+	runCmd.Flags().BoolVarP(&failSafe, failSafeName, "", failSafeDefault, "Force return 0 exit code, even in case of execution failures. Parse errors will return non-zero exit codes.")
 }
 
 //This flag stores whether the command is gauge run --failed and if it is triggering another command.
@@ -218,7 +218,7 @@ func execute(cmd *cobra.Command, args []string) {
 	installMissingPlugins(installPlugins)
 	exitCode := execution.ExecuteSpecs(specs)
 	notifyTelemetryIfNeeded(cmd, args)
-	if noExitCode {
+	if failSafe && exitCode != execution.ParseFailed {
 		exitCode = 0
 	}
 	os.Exit(exitCode)

--- a/execution/exitcode.go
+++ b/execution/exitcode.go
@@ -1,0 +1,12 @@
+package execution
+
+const (
+	// Success indicated successful operation
+	Success = 0
+	// ExecutionFailed indicates gauge's execution failed
+	ExecutionFailed = 1
+	// ParseFailed indicates one or more parse errors
+	ParseFailed = 2
+	// ValidationFailed indicates one or more validation errors
+	ValidationFailed = 3
+)


### PR DESCRIPTION
do not override fail-safe for parse errors, #1154