### PR TITLE
1112 log level override

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -239,7 +239,7 @@ var repeatLastExecution = func(cmd *cobra.Command) {
 	cmd.Execute()
 }
 
-func readPrevArgs() []string {
+var readPrevArgs = func() []string {
 	contents, err := common.ReadFileContents(filepath.Join(config.ProjectRoot, common.DotGauge, lastRunCmdFileName))
 	if err != nil {
 		logger.Fatalf(true, "Failed to read previous command information. Reason: %s", err.Error())

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"strings"
 
@@ -88,7 +89,6 @@ var (
 				exit(err, cmd.UsageString())
 			}
 			if er := handleConflictingParams(cmd.Flags(), args); er != nil {
-				fmt.Print("error")
 				exit(er, "")
 			}
 			if repeat {
@@ -191,7 +191,11 @@ func handleFlags(cmd *cobra.Command, args []string) {
 			continue
 		}
 		if v, ok := flagResetMap[f.Name]; ok {
-			args[i+1] = v
+			_, err := strconv.ParseBool(v)
+			if err != nil {
+				args[i+1] = v
+				i = i + 1
+			}
 		}
 	}
 	os.Args = args

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,14 +1,15 @@
 package cmd
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 
-	"github.com/getgauge/gauge/execution/rerun"
-
 	"github.com/getgauge/gauge/execution"
+	"github.com/getgauge/gauge/execution/rerun"
 
 	"github.com/spf13/pflag"
 
@@ -37,92 +38,130 @@ func TestMain(m *testing.M) {
 }
 
 func TestSaveCommandArgs(t *testing.T) {
-	args := []string{"gauge", "run", "specs"}
-
-	writePrevArgs(args)
-
-	prevArgs := readPrevArgs()
-	if !reflect.DeepEqual(prevArgs, args) {
-		t.Errorf("Expected %v  Got %v", args, prevArgs)
-	}
-}
-
-func TestExecuteWritesPrevCommandArgs(t *testing.T) {
-	args := []string{"gauge", "run", "specs"}
-
-	installPlugins = false
-	execution.ExecuteSpecs = func(s []string) int { return 0 }
-
 	if os.Getenv("TEST_EXITS") == "1" {
-		cmd := &cobra.Command{}
-		os.Args = args
-		execute(cmd, args)
+		args := []string{"gauge", "run", "specs"}
+
+		writePrevArgs(args)
+
+		prevArgs := readPrevArgs()
+		if !reflect.DeepEqual(prevArgs, args) {
+			fmt.Printf("Expected %v  Got %v\n", args, prevArgs)
+			os.Exit(1)
+		}
 		return
 	}
-	cmd := exec.Command(os.Args[0], "-test.run=TestExecuteWritesPrevCommandArgs")
-	cmd.Env = append(os.Environ(), "TEST_EXITS=1")
+	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+	cmd.Env = subEnv()
 	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("process ran with err %v, want exit status 0", err)
 	}
-	prevArgs := readPrevArgs()
-	if !reflect.DeepEqual(prevArgs, args) {
-		t.Errorf("Expected %v  Got %v", args, prevArgs)
+}
+
+func TestExecuteWritesPrevCommandArgs(t *testing.T) {
+	if os.Getenv("TEST_EXITS") == "1" {
+		args := []string{"gauge", "run", "specs"}
+
+		installPlugins = false
+		execution.ExecuteSpecs = func(s []string) int { return 0 }
+		cmd := &cobra.Command{}
+
+		os.Args = args
+		execute(cmd, args)
+		prevArgs := readPrevArgs()
+		if !reflect.DeepEqual(prevArgs, args) {
+			fmt.Printf("Expected %v  Got %v\n", args, prevArgs)
+			os.Exit(1)
+		}
+		return
+	}
+	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+	cmd.Env = subEnv()
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("process ran with err %v, want exit status 0", err)
 	}
 }
 
 func TestRepeatShouldPreservePreviousArgs(t *testing.T) {
-	cmd := &cobra.Command{}
+	if os.Getenv("TEST_EXITS") == "1" {
+		cmd := &cobra.Command{}
 
-	var called bool
-	writePrevArgs = func(x []string) {
-		called = true
+		var called bool
+		writePrevArgs = func(x []string) {
+			called = true
+		}
+		readPrevArgs = func() []string {
+			return []string{"gauge", "run", "specs", "-l", "debug"}
+		}
+		installPlugins = false
+		repeatLastExecution(cmd)
+
+		if called {
+			panic("Unexpected call to writePrevArgs while repeat")
+		}
+		return
 	}
-	repeatLastExecution(cmd)
-
-	if called {
-		t.Error("Unexpected call to writePrevArgs while repeat")
+	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+	cmd.Env = subEnv()
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("process ran with err %v, want exit status 0", err)
 	}
 }
 
 func TestSaveCommandArgsForFailed(t *testing.T) {
-	execution.ExecuteSpecs = func(s []string) int { return 0 }
-	rerun.GetLastState = func() ([]string, error) {
-		return []string{"run", "specs"}, nil
-	}
-	var args = []string{"gauge", "run", "--failed"}
-
 	if os.Getenv("TEST_EXITS") == "1" {
+		execution.ExecuteSpecs = func(s []string) int { return 0 }
+		rerun.GetLastState = func() ([]string, error) {
+			return []string{"run", "specs"}, nil
+		}
+		var args = []string{"gauge", "run", "--failed"}
+
+		writePrevArgs = func(a []string) {
+			if !reflect.DeepEqual(a, args) {
+				panic(fmt.Sprintf("Expected %v  Got %v", args, a))
+			}
+		}
+
 		os.Args = args
 		executeFailed(runCmd)
 		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestSaveCommandArgsForFailed")
-	cmd.Env = append(os.Environ(), []string{"TEST_EXITS=1", "GAUGE_PLUGIN_INSTALL=false"}...)
+	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+	cmd.Env = subEnv()
 	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("process ran with err %v, want exit status 0", err)
 	}
-	prevArgs := readPrevArgs()
-	if !reflect.DeepEqual(prevArgs, args) {
-		t.Errorf("Expected %v  Got %v", args, prevArgs)
-	}
 }
 
 func TestHandleConflictingParamsWithOtherArguments(t *testing.T) {
-	args := []string{"specs"}
+	if os.Getenv("TEST_EXITS") == "1" {
+		args := []string{"specs"}
 
-	var flags = pflag.FlagSet{}
-	flags.BoolP("repeat", "r", false, "")
-	flags.Set("repeat", "true")
+		var flags = pflag.FlagSet{}
+		flags.BoolP("repeat", "r", false, "")
+		flags.Set("repeat", "true")
 
-	repeat = true
-	expectedErrorMessage := "Invalid Command. Usage: gauge run --repeat"
-	err := handleConflictingParams(&flags, args)
+		repeat = true
+		expectedErrorMessage := "Invalid Command. Usage: gauge run --repeat"
+		err := handleConflictingParams(&flags, args)
 
-	if !reflect.DeepEqual(err.Error(), expectedErrorMessage) {
-		t.Errorf("Expected %v  Got %v", expectedErrorMessage, err)
+		if !reflect.DeepEqual(err.Error(), expectedErrorMessage) {
+			fmt.Printf("Expected %v  Got %v\n", expectedErrorMessage, err)
+			panic("assert failed")
+		}
+		return
+	}
+	var stdout bytes.Buffer
+	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+	cmd.Env = subEnv()
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("process ran with err %v, want exit status 0. Stdout:\n%s", err, stdout.Bytes())
 	}
 }
 
@@ -161,54 +200,68 @@ func TestHandleConflictingParamsWithJustRepeatFlag(t *testing.T) {
 }
 
 func TestHandleRerunFlagsWithVerbose(t *testing.T) {
-	cmd := &cobra.Command{}
+	if os.Getenv("TEST_EXITS") == "1" {
+		cmd := &cobra.Command{}
 
-	cmd.Flags().BoolP(verboseName, "v", verboseDefault, "Enable step level reporting on console, default being scenario level")
-	cmd.Flags().BoolP(simpleConsoleName, "", simpleConsoleDefault, "Removes colouring and simplifies the console output")
-	cmd.Flags().StringP(environmentName, "e", environmentDefault, "Specifies the environment to use")
-	cmd.Flags().StringP(tagsName, "t", tagsDefault, "Executes the specs and scenarios tagged with given tags")
-	cmd.Flags().StringP(rowsName, "r", rowsDefault, "Executes the specs and scenarios only for the selected rows. It can be specified by range as 2-4 or as list 2,4")
-	cmd.Flags().BoolP(parallelName, "p", parallelDefault, "Execute specs in parallel")
-	cmd.Flags().IntP(streamsName, "n", streamsDefault, "Specify number of parallel execution streams")
-	cmd.Flags().IntP(groupName, "g", groupDefault, "Specify which group of specification to execute based on -n flag")
-	cmd.Flags().StringP(strategyName, "", strategyDefault, "Set the parallelization strategy for execution. Possible options are: `eager`, `lazy`")
-	cmd.Flags().BoolP(sortName, "s", sortDefault, "Run specs in Alphabetical Order")
-	cmd.Flags().BoolP(installPluginsName, "i", installPluginsDefault, "Install All Missing Plugins")
-	cmd.Flags().BoolP(failedName, "f", failedDefault, "Run only the scenarios failed in previous run. This is an exclusive flag, it cannot be used in conjunction with any other argument")
-	cmd.Flags().BoolP(repeatName, "", repeatDefault, "Repeat last run. This is an exclusive flag, it cannot be used in conjunction with any other argument")
-	cmd.Flags().BoolP(hideSuggestionName, "", hideSuggestionDefault, "Prints a step implementation stub for every unimplemented step")
-	cmd.Flags().Set(repeatName, "true")
-	cmd.Flags().Set(verboseName, "true")
+		cmd.Flags().BoolP(verboseName, "v", verboseDefault, "Enable step level reporting on console, default being scenario level")
+		cmd.Flags().BoolP(simpleConsoleName, "", simpleConsoleDefault, "Removes colouring and simplifies the console output")
+		cmd.Flags().StringP(environmentName, "e", environmentDefault, "Specifies the environment to use")
+		cmd.Flags().StringP(tagsName, "t", tagsDefault, "Executes the specs and scenarios tagged with given tags")
+		cmd.Flags().StringP(rowsName, "r", rowsDefault, "Executes the specs and scenarios only for the selected rows. It can be specified by range as 2-4 or as list 2,4")
+		cmd.Flags().BoolP(parallelName, "p", parallelDefault, "Execute specs in parallel")
+		cmd.Flags().IntP(streamsName, "n", streamsDefault, "Specify number of parallel execution streams")
+		cmd.Flags().IntP(groupName, "g", groupDefault, "Specify which group of specification to execute based on -n flag")
+		cmd.Flags().StringP(strategyName, "", strategyDefault, "Set the parallelization strategy for execution. Possible options are: `eager`, `lazy`")
+		cmd.Flags().BoolP(sortName, "s", sortDefault, "Run specs in Alphabetical Order")
+		cmd.Flags().BoolP(installPluginsName, "i", installPluginsDefault, "Install All Missing Plugins")
+		cmd.Flags().BoolP(failedName, "f", failedDefault, "Run only the scenarios failed in previous run. This is an exclusive flag, it cannot be used in conjunction with any other argument")
+		cmd.Flags().BoolP(repeatName, "", repeatDefault, "Repeat last run. This is an exclusive flag, it cannot be used in conjunction with any other argument")
+		cmd.Flags().BoolP(hideSuggestionName, "", hideSuggestionDefault, "Prints a step implementation stub for every unimplemented step")
+		cmd.Flags().Set(repeatName, "true")
+		cmd.Flags().Set(verboseName, "true")
 
-	handleFlags(cmd, []string{"--repeat", "--verbose"})
-	overridenFlagValue := cmd.Flag(verboseName).Value.String()
-	expectedFlag := "true"
+		handleFlags(cmd, []string{"--repeat", "--verbose"})
+		overridenFlagValue := cmd.Flag(verboseName).Value.String()
+		expectedFlag := "true"
 
-	if !reflect.DeepEqual(overridenFlagValue, expectedFlag) {
-		t.Errorf("Expected %v  Got %v", expectedFlag, overridenFlagValue)
+		if !reflect.DeepEqual(overridenFlagValue, expectedFlag) {
+			fmt.Printf("Expected %v Got %v\n", expectedFlag, overridenFlagValue)
+			os.Exit(1)
+		}
+		return
+	}
+	var stdout bytes.Buffer
+	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+	cmd.Env = subEnv()
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("process ran with err %v, want exit status 0. Stdout:\n%s", err, stdout.Bytes())
 	}
 }
 
 func TestHandleFailedCommandForNonGaugeProject(t *testing.T) {
-	config.ProjectRoot = ""
-	currDir, _ := os.Getwd()
-	defer os.Chdir(currDir)
-	testdir := filepath.Join(currDir, "dotGauge")
-	dotgaugeDir := filepath.Join(testdir, ".gauge")
-	os.Chdir(testdir)
-	exit = func(err error, i string) {
-		if _, e := os.Stat(dotgaugeDir); os.IsExist(e) {
-			t.Fatalf("Folder .gauge is created")
-		}
-		os.Exit(0)
-	}
 	if os.Getenv("TEST_EXITS") == "1" {
+		config.ProjectRoot = ""
+		currDir, _ := os.Getwd()
+		defer os.Chdir(currDir)
+		testdir := filepath.Join(currDir, "dotGauge")
+		dotgaugeDir := filepath.Join(testdir, ".gauge")
+		os.Chdir(testdir)
+		exit = func(err error, i string) {
+			if _, e := os.Stat(dotgaugeDir); os.IsExist(e) {
+				panic("Folder .gauge is created")
+			}
+			os.Exit(0)
+		}
+
 		os.Args = []string{"gauge", "run", "-f"}
+
 		runCmd.Execute()
 		return
 	}
-	cmd := exec.Command(os.Args[0], "-test.run=TestHandleFailedCommandForNonGaugeProject")
-	cmd.Env = append(os.Environ(), "TEST_EXITS=1")
+	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+	cmd.Env = subEnv()
 	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("process ran with err %v, want exit status 0", err)
@@ -233,31 +286,34 @@ func TestHandleConflictingParamsWithLogLevelFlag(t *testing.T) {
 	}
 }
 
-func TestFailSafeShouldForceReturnZero(t *testing.T) {
-	installPlugins = false
-	// simulate failure
-	execution.ExecuteSpecs = func(s []string) int { return execution.ExecutionFailed }
-
+func TestNoExitCodeShouldForceReturnZero(t *testing.T) {
 	if os.Getenv("TEST_EXITS") == "1" {
+		installPlugins = false
+		// simulate failure
+		execution.ExecuteSpecs = func(s []string) int { return execution.ExecutionFailed }
+
 		os.Args = []string{"gauge", "run", "--fail-safe", "specs"}
+
+		failSafe = true
 		runCmd.Execute()
 		return
 	}
-	cmd := exec.Command(os.Args[0], "-test.run=TestFailSafeShouldForceReturnZero")
-	cmd.Env = append(os.Environ(), "TEST_EXITS=1")
+	var stdout bytes.Buffer
+	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+	cmd.Env = subEnv()
+	cmd.Stdout = &stdout
 	err := cmd.Run()
 	if err != nil {
-		t.Fatalf("process ran with err %v, want exit status 0", err)
+		t.Fatalf("%s process ran with err %v, want exit status 0. Stdout:\n%s", os.Args, err, stdout.Bytes())
 	}
 }
 
-func TestFailSafeShouldNotForceReturnZeroForParseErrors(t *testing.T) {
-	installPlugins = false
-	// simulate parse failure
-	execution.ExecuteSpecs = func(s []string) int { return execution.ParseFailed }
-
+func TestFailureShouldReturnExitCodeForParseErrors(t *testing.T) {
 	if os.Getenv("TEST_EXITS") == "1" {
-		os.Args = []string{"gauge", "run", "--fail-safe", "specs"}
+		// simulate parse failure
+		execution.ExecuteSpecs = func(s []string) int { return execution.ParseFailed }
+
+		os.Args = []string{"gauge", "run", "specs"}
 		runCmd.Execute()
 	}
 
@@ -280,8 +336,11 @@ func TestFailureShouldReturnExitCode(t *testing.T) {
 		runCmd.Execute()
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestFailureShouldReturnExitCode")
-	cmd.Env = append(os.Environ(), "TEST_EXITS=1")
+	var stdout bytes.Buffer
+
+	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+	cmd.Env = subEnv()
+	cmd.Stdout = &stdout
 	err := cmd.Run()
 	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
 		return
@@ -289,5 +348,72 @@ func TestFailureShouldReturnExitCode(t *testing.T) {
 	t.Fatalf("process ran with err %v, want exit status 1", err)
 }
 
-func TestLogLevelCanBeOverridden(t *testing.T) {
+func TestLogLevelCanBeOverriddenForFailed(t *testing.T) {
+	if os.Getenv("TEST_EXITS") == "1" {
+		// expect log level to be overridden
+		execution.ExecuteSpecs = func(s []string) int {
+			f, err := runCmd.Flags().GetString(logLevelName)
+			if err != nil {
+				fmt.Printf("Error parsing flags. %s\n", err.Error())
+				panic(err)
+			}
+			if f != "info" {
+				fmt.Printf("Expecting log-level=info, got %s\n", f)
+				panic("assert failure")
+			}
+			return 0
+		}
+
+		readPrevArgs = func() []string {
+			return []string{"gauge", "run", "specs", "-l", "debug"}
+		}
+		os.Args = []string{"gauge", "run", "--failed", "-l", "info"}
+		executeFailed(runCmd)
+		return
+	}
+	var stdout bytes.Buffer
+	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+	cmd.Env = subEnv()
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("process ran with err %v, want exit status 0.Stdout:\n%s", err, stdout.Bytes())
+	}
+}
+
+func TestLogLevelCanBeOverriddenForRepeat(t *testing.T) {
+	if os.Getenv("TEST_EXITS") == "1" {
+		// expect log level to be overridden
+		execution.ExecuteSpecs = func(s []string) int {
+			f, err := runCmd.Flags().GetString(logLevelName)
+			if err != nil {
+				fmt.Printf("Error parsing flags. %s\n", err.Error())
+				panic(err)
+			}
+			if f != "info" {
+				fmt.Printf("Expecting log-level=info, got %s\n", f)
+				panic("assert failure")
+			}
+			return 0
+		}
+
+		rerun.GetLastState = func() ([]string, error) {
+			return []string{"gauge", "run", "specs", "-l", "debug"}, nil
+		}
+		os.Args = []string{"gauge", "run", "--failed", "-l", "info"}
+		repeatLastExecution(runCmd)
+		return
+	}
+	var stdout bytes.Buffer
+	cmd := exec.Command(os.Args[0], fmt.Sprintf("-test.run=%s", t.Name()))
+	cmd.Env = subEnv()
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("process ran with err %v, want exit status 0.Stdout:\n%s", err, stdout.Bytes())
+	}
+}
+
+func subEnv() []string {
+	return append(os.Environ(), []string{"TEST_EXITS=1", "GAUGE_PLUGIN_INSTALL=false"}...)
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -257,3 +257,6 @@ func TestFailureShouldReturnExitCode(t *testing.T) {
 	}
 	t.Fatalf("process ran with err %v, want exit status 1", err)
 }
+
+func TestLogLevelCanBeOverridden(t *testing.T) {
+}

--- a/execution/rerun/rerun.go
+++ b/execution/rerun/rerun.go
@@ -160,7 +160,7 @@ func getJSON(failedMeta *failedMetadata) string {
 	return string(j)
 }
 
-func GetLastState() ([]string, error) {
+var GetLastState = func() ([]string, error) {
 	meta := readLastState()
 	util.SetWorkingDir(config.ProjectRoot)
 	if len(meta.FailedItems) == 0 {


### PR DESCRIPTION
log level can now be overridden in `--failed` and `--rerun` user flows.