### PR TITLE
add npm installer for gauge, #1157

### DIFF
--- a/build/npm/.gitignore
+++ b/build/npm/.gitignore
@@ -1,0 +1,3 @@
+
+node_modules
+bin

--- a/build/npm/.gitignore
+++ b/build/npm/.gitignore
@@ -1,3 +1,2 @@
 
 node_modules
-bin

--- a/build/npm/README.md
+++ b/build/npm/README.md
@@ -1,0 +1,9 @@
+# Npm installer for [gauge](https://github.com/getgauge/gauge). 
+
+This package can be used to install gauge. 
+
+## Install
+
+`npm install @gauge/cli` for installing the latest gauge version. Use `npm install @gauge/cli@<version` for installing a specific version.
+
+The gauge binary is installed at `.node_modules/bin`.

--- a/build/npm/package.json
+++ b/build/npm/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@getgauge/cli",
+  "description": "npm wrapper for installing gauge command line",
+  "scripts": {
+    "install": "node ./src/index.js",
+    "test": "mocha"
+  },
+  "bin": {
+    "gauge": "./bin/gauge"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getgauge/gauge.git"
+  },
+  "keywords": [
+    "getgauge",
+    "testing",
+    "gauge"
+  ],
+  "author": "getgauge",
+  "license": "GPL-3.0",
+  "bugs": {
+    "url": "https://github.com/getgauge/gauge/issues"
+  },
+  "homepage": "https://github.com/getgauge/gauge#readme",
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "mocha": "^5.2.0",
+    "sinon": "^6.2.0"
+  },
+  "dependencies": {
+    "request": "^2.88.0",
+    "unzipper": "^0.9.3"
+  }
+}

--- a/build/npm/src/index.js
+++ b/build/npm/src/index.js
@@ -26,4 +26,6 @@ var downloadAndExtract = async function(version) {
     });
 }
 
-install.getVersion(packageJsonPath).then((v) => downloadAndExtract(v));
+install.getVersion(packageJsonPath)
+.then((v) => downloadAndExtract(v))
+.catch((e) => console.error(e));

--- a/build/npm/src/index.js
+++ b/build/npm/src/index.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+"use strict"
+
+const install = require("./install"),
+    path = require("path"),
+    request = require('request'),
+    unzip = require('unzipper'),
+    fs = require('fs'),
+    packageJsonPath = path.join(__dirname, "..", "package.json"),
+    binPath = "./bin";
+
+
+var downloadAndExtract = async function(version) {
+    console.log(`Fetching download url for Gauge version ${version}`);
+    let url = await install.getBinaryUrl(version);
+    let gaugeExecutable = process.platform === "win32" ? "gauge.exe" : "gauge"
+    console.log(`Downloading ${url} to ${binPath}`);
+    unzip.Open.url(request, url).then((d) => {
+        return new Promise((resolve, reject) => {
+            d.files[0].stream()
+            .pipe(fs.createWriteStream(path.join(binPath, gaugeExecutable)))
+            .on('error',reject)
+            .on('finish',resolve)
+        });
+    });
+}
+
+install.getVersion(packageJsonPath).then((v) => downloadAndExtract(v));

--- a/build/npm/src/install.js
+++ b/build/npm/src/install.js
@@ -31,11 +31,7 @@ var getVersion = function(p) {
 }
 
 var getReleaseURL = function(version) {
-    if (!version) {
-        return `${BASE_URL}/latest`;
-    } else {
-        return `${BASE_URL}/tags/v${version}`;
-    }
+    return `${BASE_URL}/tags/v${version}`;
 }
 
 var getBinaryUrl = function(version) {

--- a/build/npm/src/install.js
+++ b/build/npm/src/install.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+"use strict"
+
+const fs = require('fs'),
+    request = require('request');
+
+const BASE_URL="https://api.github.com/repos/getgauge/gauge/releases",
+    ARCH_MAPPING = {
+        "ia32": "x86",
+        "x64": "x86_64"
+    },
+    PLATFORM_MAPPING = {
+        "darwin": "darwin",
+        "linux": "linux",
+        "win32": "windows"
+    };
+ 
+var getVersion = function(p) {
+    return new Promise( (resolve, reject) => {
+        if (!fs.existsSync(p)) {
+            reject("Unable to find package.json.");
+        }
+        fs.readFile(p, (err, data) => {
+            if(err) {
+                reject(err);
+            }
+            resolve(JSON.parse(data).version);   
+        })    
+    });
+}
+
+var getReleaseURL = function(version) {
+    if (!version) {
+        return `${BASE_URL}/latest`;
+    } else {
+        return `${BASE_URL}/tags/v${version}`;
+    }
+}
+
+var getBinaryUrl = function(version) {
+    return new Promise((resolve, reject) => {
+        let url = getReleaseURL(version);
+        
+        let os = PLATFORM_MAPPING[process.platform];
+        let arch = ARCH_MAPPING[process.arch];
+
+        request.get(url, { headers: {'user-agent': 'node.js'}, json: true}, (err, res, data) => {
+            try {
+                for (const key in data.assets) {
+                    if (data.assets.hasOwnProperty(key)) {
+                        const a = data.assets[key];
+                        if(a.browser_download_url.indexOf(`${os}.${arch}.zip`) >= 0) {
+                            resolve(a.browser_download_url);
+                        }
+                    }
+                }
+                reject(new Error(`No download link found for version ${version}, OS: ${os}, Arch: ${arch}`));
+            } catch (error) {
+                reject(error);
+            }
+        });
+    });
+}
+
+module.exports = {
+    getVersion: getVersion,
+    getReleaseURL: getReleaseURL,
+    getBinaryUrl: getBinaryUrl
+}

--- a/build/npm/test/test.js
+++ b/build/npm/test/test.js
@@ -1,0 +1,75 @@
+"use strict"
+
+const expect  = require('chai').expect,
+    fs = require('fs'),
+    sinon = require('sinon'),
+    request = require('request');
+
+var subject = require("../src/install");
+
+describe("getVersion", () => {
+    it("should get the version in package.json", async () => {
+        const dummyPath = "/foo/bar";
+        sinon.stub(fs, "existsSync").returns(true);
+        sinon.stub(fs, "readFile").withArgs(dummyPath).yields(undefined, '{"version": "x.y.z"}');
+        
+        expect(await subject.getVersion(dummyPath)).equal("x.y.z");
+    });
+});
+
+describe("getReleaseURl", () => {
+    it("should get latest url", () => {
+        let url = subject.getReleaseURL();
+
+        expect(url).equals("https://api.github.com/repos/getgauge/gauge/releases/latest");
+    });
+
+    it("should get url for version", () => {
+        let version = "1.0.0";
+        let url = subject.getReleaseURL(version);
+
+        expect(url).equals("https://api.github.com/repos/getgauge/gauge/releases/tags/v" + version);
+    })
+});
+
+describe("getBinaryMeta", () => {
+    it("should fetch platform specific metadata", async () => {
+        let url = subject.getReleaseURL();
+        let response = {
+            assets: {
+                0 : {
+                    browser_download_url: "https://github.com/getgauge/gauge/releases/download/v1.0.0/gauge-1.0.0-darwin.x86.zip"
+                },
+                1 : {
+                    browser_download_url: "https://github.com/getgauge/gauge/releases/download/v1.0.0/gauge-1.0.0-darwin.x86_64.zip"
+                },
+                2 : {
+                    browser_download_url: "https://github.com/getgauge/gauge/releases/download/v1.0.0/gauge-1.0.0-linux.x86.zip"
+                },
+                3 : {
+                    browser_download_url: "https://github.com/getgauge/gauge/releases/download/v1.0.0/gauge-1.0.0-linux.x86_64.zip"
+                },
+                4 : {
+                    browser_download_url: "https://github.com/getgauge/gauge/releases/download/v1.0.0/gauge-1.0.0-windows.x86.zip"
+                },
+                5 : {
+                    browser_download_url: "https://github.com/getgauge/gauge/releases/download/v1.0.0/gauge-1.0.0-windows.x86_64.zip"
+                },
+
+            }
+        }
+        sinon.stub(request, 'get').yields(undefined, undefined, response);
+
+        let originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');;
+        let originalArch = Object.getOwnPropertyDescriptor(process, 'arch');;
+        Object.defineProperty(process, 'platform', { value: "win32" });
+        Object.defineProperty(process, 'arch', { value: "ia32" });
+        
+        expect(await subject.getBinaryUrl()).equals("https://github.com/getgauge/gauge/releases/download/v1.0.0/gauge-1.0.0-windows.x86.zip");
+
+        Object.defineProperty(process, 'platform', originalPlatform);
+        Object.defineProperty(process, 'arch', originalArch);
+    });
+});
+
+

--- a/build/npm/test/test.js
+++ b/build/npm/test/test.js
@@ -18,12 +18,6 @@ describe("getVersion", () => {
 });
 
 describe("getReleaseURl", () => {
-    it("should get latest url", () => {
-        let url = subject.getReleaseURL();
-
-        expect(url).equals("https://api.github.com/repos/getgauge/gauge/releases/latest");
-    });
-
     it("should get url for version", () => {
         let version = "1.0.0";
         let url = subject.getReleaseURL(version);


### PR DESCRIPTION
publishes a npm installer to `@getgauge/cli`

version has been removed from `package.json`. this needs a `npm version <version>` before running `npm publish`

pipeline has been set for this.
