### PR TITLE
1158 exit on runner crash

### DIFF
--- a/conn/connectionHandler.go
+++ b/conn/connectionHandler.go
@@ -23,6 +23,8 @@ import (
 	"net"
 	"time"
 
+	"github.com/getgauge/gauge/logger"
+
 	"github.com/golang/protobuf/proto"
 )
 
@@ -107,8 +109,7 @@ func (connectionHandler *GaugeConnectionHandler) handleConnectionMessages(conn n
 		n, err := conn.Read(data)
 		if err != nil {
 			conn.Close()
-			//TODO: Move to file
-			//			logger.Log.Println(fmt.Sprintf("Closing connection [%s] cause: %s", connectionHandler.conn.RemoteAddr(), err.Error()))
+			logger.Infof(false, "Closing connection [%s] cause: %s", conn.RemoteAddr(), err.Error())
 			return
 		}
 

--- a/execution/parallelExecution_test.go
+++ b/execution/parallelExecution_test.go
@@ -147,7 +147,7 @@ func (f *fakeRunner) ExecuteMessageWithTimeout(m *gauge_messages.Message) (*gaug
 func (f *fakeRunner) ExecuteAndGetStatus(m *gauge_messages.Message) *gauge_messages.ProtoExecutionResult {
 	return nil
 }
-func (f *fakeRunner) IsProcessRunning() bool {
+func (f *fakeRunner) Alive() bool {
 	return false
 }
 func (f *fakeRunner) Kill() error {

--- a/execution/specExecutor_test.go
+++ b/execution/specExecutor_test.go
@@ -262,7 +262,7 @@ func (r *mockRunner) ExecuteAndGetStatus(m *gauge_messages.Message) *gauge_messa
 	return r.ExecuteAndGetStatusFunc(m)
 }
 
-func (r *mockRunner) IsProcessRunning() bool {
+func (r *mockRunner) Alive() bool {
 	return false
 }
 

--- a/runner/grpcRunner.go
+++ b/runner/grpcRunner.go
@@ -108,7 +108,7 @@ func (r *GrpcRunner) ExecuteMessageWithTimeout(message *gm.Message) (*gm.Message
 func (r *GrpcRunner) ExecuteAndGetStatus(m *gm.Message) *gm.ProtoExecutionResult {
 	return nil
 }
-func (r *GrpcRunner) IsProcessRunning() bool {
+func (r *GrpcRunner) Alive() bool {
 	return false
 }
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -448,18 +448,19 @@ func Start(manifest *manifest.Manifest, outputStreamWriter io.Writer, killChanne
 	if err != nil {
 		return nil, err
 	}
-	return connect(handler, runner)
+	err = connect(handler, runner)
+	return runner, err
 }
 
-func connect(h *conn.GaugeConnectionHandler, runner *LanguageRunner) (Runner, error) {
+func connect(h *conn.GaugeConnectionHandler, runner *LanguageRunner) error {
 	connection, connErr := h.AcceptConnection(config.RunnerConnectionTimeout(), runner.errorChannel)
 	if connErr != nil {
 		logger.Debugf(true, "Runner connection error: %s", connErr)
 		if err := runner.killRunner(); err != nil {
 			logger.Debugf(true, "Error while killing runner: %s", err)
 		}
-		return nil, connErr
+		return connErr
 	}
 	runner.connection = connection
-	return runner, nil
+	return nil
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -219,9 +219,8 @@ func (r *LanguageRunner) EnsureConnected() bool {
 	c := r.connection
 	c.SetReadDeadline(time.Now())
 	var one []byte
-	if _, err := c.Read(one); err != nil {
-		_, ok := err.(*net.OpError)
-		r.lostContact = ok || err == io.EOF
+	if _, err := c.Read(one); err == io.EOF {
+		r.lostContact = true
 		logger.Fatalf(true, "Connection to runner with Pid %d lost. The runner probably quit unexpectedly. Inspect logs for potential reasons. Error : %s", r.Cmd.Process.Pid, err.Error())
 	}
 	var zero time.Time

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -46,7 +46,7 @@ import (
 type Runner interface {
 	ExecuteAndGetStatus(m *gauge_messages.Message) *gauge_messages.ProtoExecutionResult
 	ExecuteMessageWithTimeout(m *gauge_messages.Message) (*gauge_messages.Message, error)
-	IsProcessRunning() bool
+	Alive() bool
 	Kill() error
 	Connection() net.Conn
 	IsMultithreaded() bool
@@ -59,15 +59,16 @@ type LanguageRunner struct {
 	connection    net.Conn
 	errorChannel  chan error
 	multiThreaded bool
+	lostContact   bool
 }
 
 type MultithreadedRunner struct {
 	r *LanguageRunner
 }
 
-func (r *MultithreadedRunner) IsProcessRunning() bool {
+func (r *MultithreadedRunner) Alive() bool {
 	if r.r.mutex != nil && r.r.Cmd != nil {
-		return r.r.IsProcessRunning()
+		return r.r.Alive()
 	}
 	return false
 }
@@ -87,7 +88,7 @@ func (r *MultithreadedRunner) Kill() error {
 	exited := make(chan bool, 1)
 	go func() {
 		for {
-			if r.IsProcessRunning() {
+			if r.Alive() {
 				time.Sleep(100 * time.Millisecond)
 			} else {
 				exited <- true
@@ -128,6 +129,7 @@ func (r *MultithreadedRunner) ExecuteAndGetStatus(message *gauge_messages.Messag
 }
 
 func (r *MultithreadedRunner) ExecuteMessageWithTimeout(message *gauge_messages.Message) (*gauge_messages.Message, error) {
+	r.r.EnsureConnected()
 	return conn.GetResponseForMessageWithTimeout(message, r.r.Connection(), config.RunnerRequestTimeout())
 }
 
@@ -202,11 +204,29 @@ func GetRunnerInfo(language string) (*RunnerInfo, error) {
 	}
 	return runnerInfo, nil
 }
-func (r *LanguageRunner) IsProcessRunning() bool {
+
+func (r *LanguageRunner) Alive() bool {
 	r.mutex.Lock()
 	ps := r.Cmd.ProcessState
 	r.mutex.Unlock()
 	return ps == nil || !ps.Exited()
+}
+
+func (r *LanguageRunner) EnsureConnected() bool {
+	if r.lostContact {
+		return false
+	}
+	c := r.connection
+	c.SetReadDeadline(time.Now())
+	var one []byte
+	if _, err := c.Read(one); err != nil {
+		_, ok := err.(*net.OpError)
+		r.lostContact = ok || err == io.EOF
+		logger.Fatalf(true, "Connection to runner with Pid %d lost. The runner probably quit unexpectedly. Inspect logs for potential reasons. Error : %s", r.Cmd.Process.Pid, err.Error())
+	}
+	var zero time.Time
+	c.SetReadDeadline(zero)
+	return true
 }
 
 func (r *LanguageRunner) IsMultithreaded() bool {
@@ -214,14 +234,14 @@ func (r *LanguageRunner) IsMultithreaded() bool {
 }
 
 func (r *LanguageRunner) Kill() error {
-	if r.IsProcessRunning() {
+	if r.Alive() {
 		defer r.connection.Close()
 		conn.SendProcessKillMessage(r.connection)
 
 		exited := make(chan bool, 1)
 		go func() {
 			for {
-				if r.IsProcessRunning() {
+				if r.Alive() {
 					time.Sleep(100 * time.Millisecond)
 				} else {
 					exited <- true
@@ -255,7 +275,11 @@ func (r *LanguageRunner) Pid() int {
 	return r.Cmd.Process.Pid
 }
 
+// ExecuteAndGetStatus invokes the runner with a request and waits for response. error is thrown only when unable to connect to runner
 func (r *LanguageRunner) ExecuteAndGetStatus(message *gauge_messages.Message) *gauge_messages.ProtoExecutionResult {
+	if !r.EnsureConnected() {
+		return nil
+	}
 	response, err := conn.GetResponseForMessageWithTimeout(message, r.connection, 0)
 	if err != nil {
 		return &gauge_messages.ProtoExecutionResult{Failed: true, ErrorMessage: err.Error()}
@@ -276,6 +300,7 @@ func (r *LanguageRunner) ExecuteAndGetStatus(message *gauge_messages.Message) *g
 }
 
 func (r *LanguageRunner) ExecuteMessageWithTimeout(message *gauge_messages.Message) (*gauge_messages.Message, error) {
+	r.EnsureConnected()
 	return conn.GetResponseForMessageWithTimeout(message, r.Connection(), config.RunnerRequestTimeout())
 }
 

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -293,7 +293,7 @@ func (r *mockRunner) ExecuteAndGetStatus(m *gauge_messages.Message) *gauge_messa
 	return nil
 }
 
-func (r *mockRunner) IsProcessRunning() bool {
+func (r *mockRunner) Alive() bool {
 	return false
 }
 


### PR DESCRIPTION
exit gauge on runner connection close. this will prevent gauge from executing steps once it's connection is closed (abnormally).