### PR TITLE
fixing getting started link to https://gauge.org/getting-started-guid…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Gauge is a light weight cross-platform test automation tool. It provides the ability to author test cases in the business language.
 
 ## Get Started
-Read more about [Why Gauge](https://blog.getgauge.io/why-we-built-gauge-6e31bb4848cd) can be used, its [terminologies](https://docs.gauge.org/latest/writing-specifications.html) and [**get started...**](https://gauge.org/get-started.html)
+Read more about [Why Gauge](https://blog.getgauge.io/why-we-built-gauge-6e31bb4848cd) can be used, its [terminologies](https://docs.gauge.org/latest/writing-specifications.html) and [**get started...**](https://gauge.org/getting-started-guide/we-start/)
 
 ## Find out more
 


### PR DESCRIPTION
Link for get started at README.md is https://gauge.org/get-started.html which is wrong. It should be https://gauge.org/getting-started-guide/we-start/