### PR TITLE
Ensure that errors from post install propagate to npm

### DIFF
--- a/build/npm/src/index.js
+++ b/build/npm/src/index.js
@@ -16,7 +16,7 @@ var downloadAndExtract = async function(version) {
     let url = await install.getBinaryUrl(version);
     let gaugeExecutable = process.platform === "win32" ? "gauge.exe" : "gauge"
     console.log(`Downloading ${url} to ${binPath}`);
-    unzip.Open.url(request, url).then((d) => {
+    return unzip.Open.url(request, url).then((d) => {
         return new Promise((resolve, reject) => {
             d.files[0].stream()
             .pipe(fs.createWriteStream(path.join(binPath, gaugeExecutable)))


### PR DESCRIPTION
We use gauge in our CI environment to control our end to end tests. Unfortunately the npm install sometimes has an error during the download. Because of the lack of return npm does not realise that there has been an error and therefore exits with a 0. This causes our build to continue and to attempt to use gauge when the binary isn't available.

This fix is intended to make the failure to download as part of the install script recognised by npm and therefore exit with the correct status.