### PR TITLE
Sets gauge environment variable based on selected env

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -37,6 +37,8 @@ const (
 	SpecsDir = "gauge_specs_dir"
 	// GaugeReportsDir holds the location of reports
 	GaugeReportsDir = "gauge_reports_dir"
+	// GaugeEnvironment holds the name of the current environment
+	GaugeEnvironment = "gauge_environment"
 	// LogsDirectory holds the location of log files
 	LogsDirectory = "logs_directory"
 	// OverwriteReports = false will create a new directory for reports
@@ -56,7 +58,7 @@ const (
 
 var envVars map[string]string
 
-var currentEnvironments = []string{"default"}
+var currentEnvironments = []string{common.DefaultEnvDir}
 
 // LoadEnv first generates the map of the env vars that needs to be set.
 // It starts by populating the map with the env passed by the user in --env flag.
@@ -78,7 +80,7 @@ func LoadEnv(envName string) error {
 			return fmt.Errorf("Failed to load env. %s", err.Error())
 		}
 
-		if env == "default" {
+		if env == common.DefaultEnvDir {
 			defaultEnvLoaded = true
 		} else {
 			currentEnvironments = append(currentEnvironments, env)
@@ -86,7 +88,7 @@ func LoadEnv(envName string) error {
 	}
 
 	if !defaultEnvLoaded {
-		err := loadEnvDir("default")
+		err := loadEnvDir(common.DefaultEnvDir)
 		if err != nil {
 			return fmt.Errorf("Failed to load env. %s", err.Error())
 		}
@@ -109,6 +111,7 @@ func LoadEnv(envName string) error {
 func loadDefaultEnvVars() {
 	addEnvVar(SpecsDir, "specs")
 	addEnvVar(GaugeReportsDir, "reports")
+	addEnvVar(GaugeEnvironment, common.DefaultEnvDir)
 	addEnvVar(LogsDirectory, "logs")
 	addEnvVar(OverwriteReports, "true")
 	addEnvVar(ScreenshotOnFailure, "true")
@@ -122,12 +125,13 @@ func loadDefaultEnvVars() {
 func loadEnvDir(envName string) error {
 	envDirPath := filepath.Join(config.ProjectRoot, common.EnvDirectoryName, envName)
 	if !common.DirExists(envDirPath) {
-		if envName != "default" {
+		if envName != common.DefaultEnvDir {
 			return fmt.Errorf("%s environment does not exist", envName)
 		}
 		return nil
 	}
-
+	addEnvVar(GaugeEnvironment, envName)
+	logger.Debugf(true, "'%s' set to '%s'", GaugeEnvironment, envName)
 	return filepath.Walk(envDirPath, loadEnvFile)
 }
 

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -39,6 +39,7 @@ func (s *MySuite) TestLoadDefaultEnv(c *C) {
 
 	c.Assert(e, Equals, nil)
 	c.Assert(os.Getenv("gauge_reports_dir"), Equals, "reports")
+	c.Assert(os.Getenv("gauge_environment"), Equals, "default")
 	c.Assert(os.Getenv("overwrite_reports"), Equals, "true")
 	c.Assert(os.Getenv("screenshot_on_failure"), Equals, "true")
 	c.Assert(os.Getenv("logs_directory"), Equals, "logs")
@@ -56,6 +57,7 @@ func (s *MySuite) TestLoadDefaultEnvFromDirIfPresent(c *C) {
 
 	c.Assert(e, Equals, nil)
 	c.Assert(os.Getenv("gauge_reports_dir"), Equals, "reports_dir")
+	c.Assert(os.Getenv("gauge_environment"), Equals, "foo")
 	c.Assert(os.Getenv("overwrite_reports"), Equals, "false")
 	c.Assert(os.Getenv("screenshot_on_failure"), Equals, "false")
 	c.Assert(os.Getenv("logs_directory"), Equals, "logs")
@@ -73,6 +75,7 @@ func (s *MySuite) TestLoadDefaultEnvFromDirAndOverwritePassedEnv(c *C) {
 
 	c.Assert(e, Equals, nil)
 	c.Assert(os.Getenv("gauge_reports_dir"), Equals, "reports_dir")
+	c.Assert(os.Getenv("gauge_environment"), Equals, "bar")
 	c.Assert(os.Getenv("overwrite_reports"), Equals, "false")
 	c.Assert(os.Getenv("screenshot_on_failure"), Equals, "true")
 	c.Assert(os.Getenv("logs_directory"), Equals, "bar/logs")
@@ -87,6 +90,7 @@ func (s *MySuite) TestLoadDefaultEnvEvenIfDefaultEnvNotPresent(c *C) {
 
 	c.Assert(e, Equals, nil)
 	c.Assert(os.Getenv("gauge_reports_dir"), Equals, "reports")
+	c.Assert(os.Getenv("gauge_environment"), Equals, "default")
 	c.Assert(os.Getenv("overwrite_reports"), Equals, "true")
 	c.Assert(os.Getenv("screenshot_on_failure"), Equals, "true")
 	c.Assert(os.Getenv("logs_directory"), Equals, "logs")

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/getgauge/common"
 	"github.com/getgauge/gauge/config"
 	. "gopkg.in/check.v1"
 )
@@ -35,11 +36,11 @@ func (s *MySuite) TestLoadDefaultEnv(c *C) {
 	os.Clearenv()
 	config.ProjectRoot = "_testdata/proj1"
 
-	e := LoadEnv("default")
+	e := LoadEnv(common.DefaultEnvDir)
 
 	c.Assert(e, Equals, nil)
 	c.Assert(os.Getenv("gauge_reports_dir"), Equals, "reports")
-	c.Assert(os.Getenv("gauge_environment"), Equals, "default")
+	c.Assert(os.Getenv("gauge_environment"), Equals, common.DefaultEnvDir)
 	c.Assert(os.Getenv("overwrite_reports"), Equals, "true")
 	c.Assert(os.Getenv("screenshot_on_failure"), Equals, "true")
 	c.Assert(os.Getenv("logs_directory"), Equals, "logs")
@@ -86,11 +87,11 @@ func (s *MySuite) TestLoadDefaultEnvEvenIfDefaultEnvNotPresent(c *C) {
 	os.Clearenv()
 	config.ProjectRoot = ""
 
-	e := LoadEnv("default")
+	e := LoadEnv(common.DefaultEnvDir)
 
 	c.Assert(e, Equals, nil)
 	c.Assert(os.Getenv("gauge_reports_dir"), Equals, "reports")
-	c.Assert(os.Getenv("gauge_environment"), Equals, "default")
+	c.Assert(os.Getenv("gauge_environment"), Equals, common.DefaultEnvDir)
 	c.Assert(os.Getenv("overwrite_reports"), Equals, "true")
 	c.Assert(os.Getenv("screenshot_on_failure"), Equals, "true")
 	c.Assert(os.Getenv("logs_directory"), Equals, "logs")
@@ -104,7 +105,7 @@ func (s *MySuite) TestLoadDefaultEnvWithOtherPropertiesSetInShell(c *C) {
 	os.Setenv("gauge_specs_dir", "custom_specs_dir")
 	config.ProjectRoot = "_testdata/proj1"
 
-	e := LoadEnv("default")
+	e := LoadEnv(common.DefaultEnvDir)
 
 	c.Assert(e, Equals, nil)
 	c.Assert(os.Getenv("foo"), Equals, "bar")
@@ -117,7 +118,7 @@ func (s *MySuite) TestLoadDefaultEnvWithOtherPropertiesNotSetInShell(c *C) {
 	os.Clearenv()
 	config.ProjectRoot = "_testdata/proj1"
 
-	e := LoadEnv("default")
+	e := LoadEnv(common.DefaultEnvDir)
 
 	c.Assert(e, Equals, nil)
 	c.Assert(os.Getenv("property1"), Equals, "value1")
@@ -207,7 +208,7 @@ func (s *MySuite) TestLoadDefaultEnvWithSubstitutedVariables(c *C) {
 
 	config.ProjectRoot = "_testdata/proj3"
 
-	e := LoadEnv("default")
+	e := LoadEnv(common.DefaultEnvDir)
 
 	c.Assert(e, Equals, nil)
 
@@ -219,7 +220,7 @@ func (s *MySuite) TestLoadDefaultEnvWithSubstitutedVariables(c *C) {
 
 func (s *MySuite) TestLoadDefaultEnvWithInvalidSubstitutedVariable(c *C) {
 	config.ProjectRoot = "_testdata/proj3"
-	e := LoadEnv("default")
+	e := LoadEnv(common.DefaultEnvDir)
 	c.Assert(e, ErrorMatches, ".*env variable was not set")
 }
 


### PR DESCRIPTION
Fix for #1333 

This is an initial PR to set `gauge_environment` variable. The language runner could then use this to expose in the API.