### PR TITLE
Retain name of arg while setting arg value

### DIFF
--- a/gauge/arg.go
+++ b/gauge/arg.go
@@ -56,6 +56,7 @@ func (lookup *ArgLookup) AddArgValue(param string, stepArg *StepArg) error {
 	if !ok {
 		return fmt.Errorf("Accessing an invalid parameter (%s)", param)
 	}
+	stepArg.Name = param
 	lookup.paramValue[paramIndex].stepArg = stepArg
 	return nil
 }

--- a/gauge/arg_test.go
+++ b/gauge/arg_test.go
@@ -54,6 +54,7 @@ func (s *MySuite) TestAddArgValue(c *C) {
 	stepArg, err = lookup.GetArg("param2")
 	c.Assert(err, IsNil)
 	c.Assert(stepArg.Value, Equals, "value2")
+	c.Assert(stepArg.Name, Equals, "param2")
 }
 
 func (s *MySuite) TestErrorForInvalidArg(c *C) {
@@ -74,6 +75,7 @@ func (s *MySuite) TestGetLookupCopy(c *C) {
 	stepArg, err := copiedLookup.GetArg("param1")
 	c.Assert(err, IsNil)
 	c.Assert(stepArg.Value, Equals, "new value")
+	c.Assert(stepArg.Name, Equals, "param1")
 	stepArg, err = originalLookup.GetArg("param1")
 	c.Assert(err, IsNil)
 	c.Assert(stepArg.Value, Equals, "oldValue")


### PR DESCRIPTION
In the function `AddArgValue`, the `stepArg.Name` is lost since `stepArg` is re-assigned while assigning the value of it. This commit ensures it is assigned back. 

If `name` of argument is not set, the result received by reporting plugins will have name for it's step parameter as empty. As a result, it cannot be mapped to placeholder in step text. 