### PR TITLE
Added flag to set max retries count for failed scenario

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -202,6 +202,7 @@ func initPackageFlags() {
 	}
 	filter.ScenariosName = scenarios
 	execution.MaxRetriesCount = maxRetriesCount
+	execution.RetryOnlyTags = retryOnlyTags
 }
 
 var exit = func(err error, additionalText string) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -201,6 +201,7 @@ func initPackageFlags() {
 		execution.Strategy = execution.Eager
 	}
 	filter.ScenariosName = scenarios
+	execution.MaxRetriesCount = maxRetriesCount
 }
 
 var exit = func(err error, additionalText string) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -49,6 +49,7 @@ const (
 	strategyDefault        = "lazy"
 	onlyDefault            = ""
 	groupDefault           = -1
+	maxRetriesCountDefault = 1
 	failSafeDefault        = false
 	skipCommandSaveDefault = false
 
@@ -64,6 +65,7 @@ const (
 	rowsName            = "table-rows"
 	strategyName        = "strategy"
 	groupName           = "group"
+	maxRetriesCountName = "max-retries-count"
 	streamsName         = "n"
 	onlyName            = "only"
 	failSafeName        = "fail-safe"
@@ -111,6 +113,7 @@ var (
 	rows                       string
 	strategy                   string
 	streams                    int
+	maxRetriesCount            int
 	group                      int
 	failSafe                   bool
 	skipCommandSave            bool
@@ -128,6 +131,7 @@ func init() {
 	f.StringVarP(&rows, rowsName, "r", rowsDefault, "Executes the specs and scenarios only for the selected rows. It can be specified by range as 2-4 or as list 2,4")
 	f.BoolVarP(&parallel, parallelName, "p", parallelDefault, "Execute specs in parallel")
 	f.IntVarP(&streams, streamsName, "n", streamsDefault, "Specify number of parallel execution streams")
+	f.IntVarP(&maxRetriesCount, maxRetriesCountName, "c", maxRetriesCountDefault, "Max count of iterations for failed scenario")
 	f.StringVarP(&tagsToFilterForParallelRun, onlyName, "o", onlyDefault, "Specify number of parallel execution streams")
 	f.MarkHidden(onlyName)
 	f.IntVarP(&group, groupName, "g", groupDefault, "Specify which group of specification to execute based on -n flag")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -50,6 +50,7 @@ const (
 	onlyDefault            = ""
 	groupDefault           = -1
 	maxRetriesCountDefault = 1
+	retryOnlyTagsDefault   = ""
 	failSafeDefault        = false
 	skipCommandSaveDefault = false
 
@@ -66,6 +67,7 @@ const (
 	strategyName        = "strategy"
 	groupName           = "group"
 	maxRetriesCountName = "max-retries-count"
+	retryOnlyTagsName   = "retry-only"
 	streamsName         = "n"
 	onlyName            = "only"
 	failSafeName        = "fail-safe"
@@ -114,6 +116,7 @@ var (
 	strategy                   string
 	streams                    int
 	maxRetriesCount            int
+	retryOnlyTags              string
 	group                      int
 	failSafe                   bool
 	skipCommandSave            bool
@@ -132,6 +135,7 @@ func init() {
 	f.BoolVarP(&parallel, parallelName, "p", parallelDefault, "Execute specs in parallel")
 	f.IntVarP(&streams, streamsName, "n", streamsDefault, "Specify number of parallel execution streams")
 	f.IntVarP(&maxRetriesCount, maxRetriesCountName, "c", maxRetriesCountDefault, "Max count of iterations for failed scenario")
+	f.StringVarP(&retryOnlyTags, retryOnlyTagsName, "", retryOnlyTagsDefault, "Retries the specs and scenarios tagged with given tags")
 	f.StringVarP(&tagsToFilterForParallelRun, onlyName, "o", onlyDefault, "Specify number of parallel execution streams")
 	f.MarkHidden(onlyName)
 	f.IntVarP(&group, groupName, "g", groupDefault, "Specify which group of specification to execute based on -n flag")
@@ -239,13 +243,15 @@ func handleConflictingParams(setFlags *pflag.FlagSet, args []string) error {
 	})
 	if repeat && len(args)+flagDiffCount > 1 {
 		return fmt.Errorf("Invalid Command. Usage: gauge run --repeat")
-
 	}
 	if failed && len(args)+flagDiffCount > 1 {
 		return fmt.Errorf("Invalid Command. Usage: gauge run --failed")
 	}
 	if !parallel && tagsToFilterForParallelRun != "" {
 		return fmt.Errorf("Invalid Command. flag --only can be used only with --parallel")
+	}
+	if maxRetriesCount == 1 && retryOnlyTags != "" {
+		return fmt.Errorf("Invalid Command. flag --retry-only can be used only with --max-retry-count")
 	}
 	return nil
 }

--- a/execution/execute.go
+++ b/execution/execute.go
@@ -70,6 +70,9 @@ const (
 	executionStatusFile = "executionStatus.json"
 )
 
+// Count of iterations
+var MaxRetriesCount int
+
 // NumberOfExecutionStreams shows the number of execution streams, in parallel execution.
 var NumberOfExecutionStreams int
 

--- a/execution/execute.go
+++ b/execution/execute.go
@@ -73,6 +73,9 @@ const (
 // Count of iterations
 var MaxRetriesCount int
 
+// Tags to filter specs/scenarios to retry
+var RetryOnlyTags string
+
 // NumberOfExecutionStreams shows the number of execution streams, in parallel execution.
 var NumberOfExecutionStreams int
 

--- a/execution/execute.go
+++ b/execution/execute.go
@@ -283,6 +283,9 @@ func printExecutionResult(suiteResult *result.SuiteResult, isParsingOk bool) int
 }
 
 func validateFlags() error {
+	if MaxRetriesCount < 1 {
+		return fmt.Errorf("invalid input(%s) to --max-retries-count flag", strconv.Itoa(MaxRetriesCount))
+	}
 	if !InParallel {
 		return nil
 	}

--- a/execution/specExecutor.go
+++ b/execution/specExecutor.go
@@ -274,8 +274,7 @@ func (e *specExecutor) executeScenarios(scenarios []*gauge.Scenario) ([]result.R
 func (e *specExecutor) executeScenario(scenario *gauge.Scenario) (*result.ScenarioResult, error) {
 	var scenarioResult *result.ScenarioResult
 
-	i := 1
-	for {
+	for i := 0; i < MaxRetriesCount; i++ {
 		e.currentExecutionInfo.CurrentScenario = &gauge_messages.ScenarioInfo{
 			Name:     scenario.Heading.Value,
 			Tags:     getTagValue(scenario.Tags),
@@ -298,10 +297,9 @@ func (e *specExecutor) executeScenario(scenario *gauge.Scenario) (*result.Scenar
 			e.specResult.ScenarioSkippedCount++
 		}
 
-		if !scenarioResult.GetFailed() || i >= MaxRetriesCount {
+		if !scenarioResult.GetFailed() {
 			break
 		}
-		i++
 	}
 	return scenarioResult, nil
 }

--- a/execution/specExecutor_test.go
+++ b/execution/specExecutor_test.go
@@ -173,6 +173,7 @@ func (s *MySuite) TestSpecIsSkippedIfDataRangeIsInvalid(c *C) {
 }
 
 func (s *MySuite) TestDataTableRowsAreSkippedForUnimplemetedStep(c *C) {
+	MaxRetriesCount = 1
 	stepText := "Unimplememted step"
 
 	specText := newSpecBuilder().specHeading("A spec heading").
@@ -607,6 +608,7 @@ func (e *mockExecutor) execute(i gauge.Item, r result.Result) {
 }
 
 func TestExecuteScenario(t *testing.T) {
+	MaxRetriesCount = 1
 	errs := gauge.NewBuildErrors()
 	se := newSpecExecutor(exampleSpecWithScenarios, nil, nil, errs, 0)
 	executedScenarios := make([]string, 0)

--- a/execution/specExecutor_test.go
+++ b/execution/specExecutor_test.go
@@ -640,8 +640,7 @@ func TestExecuteScenarioWithRetries(t *testing.T) {
 	se.scenarioExecutor = &mockExecutor{
 		executeFunc: func(i gauge.Item, r result.Result) {
 			if count < MaxRetriesCount {
-				r.(*result.ScenarioResult).ProtoScenario.Failed = true
-				r.(*result.ScenarioResult).ProtoScenario.ExecutionStatus = gauge_messages.ExecutionStatus_FAILED
+				r.SetFailure()
 			} else {
 				r.(*result.ScenarioResult).ProtoScenario.ExecutionStatus = gauge_messages.ExecutionStatus_PASSED
 			}
@@ -655,6 +654,73 @@ func TestExecuteScenarioWithRetries(t *testing.T) {
 	if sceResult.GetFailed() {
 		t.Errorf("Expect sceResult.GetFailed() = false, got true")
 	}
+}
+
+var exampleSpecWithTags = &gauge.Specification{
+	Heading:  &gauge.Heading{Value: "Example Spec"},
+	FileName: "example.spec",
+	Tags:     &gauge.Tags{RawValues: [][]string{{"tagSpec"}}},
+	Scenarios: []*gauge.Scenario{
+		&gauge.Scenario{Heading: &gauge.Heading{Value: "Example Scenario 1"}, Items: make([]gauge.Item, 0), Tags: &gauge.Tags{RawValues: [][]string{{"tagSce"}}}, Span: &gauge.Span{}},
+	},
+}
+
+func TestExecuteScenarioShouldNotRetryIfNotMatchTags(t *testing.T) {
+	MaxRetriesCount = 2
+	RetryOnlyTags = "tagN"
+
+	se := newSpecExecutorForTestsWithRetry()
+	sceResult, _ := se.executeScenario(exampleSpecWithTags.Scenarios[0])
+
+	if !sceResult.GetFailed() {
+		t.Errorf("Expect sceResult.GetFailed() = true, got false")
+	}
+}
+
+func TestExecuteScenarioShouldRetryIfSpecificationMatchTags(t *testing.T) {
+	MaxRetriesCount = 2
+	RetryOnlyTags = "tagSpec"
+
+	se := newSpecExecutorForTestsWithRetry()
+
+	sceResult, _ := se.executeScenario(exampleSpecWithTags.Scenarios[0])
+
+	if sceResult.GetFailed() {
+		t.Errorf("Expect sceResult.GetFailed() = false, got true")
+	}
+}
+
+func TestExecuteScenarioShouldRetryIfScenarioMatchTags(t *testing.T) {
+	MaxRetriesCount = 2
+	RetryOnlyTags = "tagSce"
+
+	se := newSpecExecutorForTestsWithRetry()
+
+	sceResult, _ := se.executeScenario(exampleSpecWithTags.Scenarios[0])
+
+	if sceResult.GetFailed() {
+		t.Errorf("Expect sceResult.GetFailed() = false, got true")
+	}
+}
+
+func newSpecExecutorForTestsWithRetry() *specExecutor {
+	errs := gauge.NewBuildErrors()
+	se := newSpecExecutor(exampleSpecWithTags, nil, nil, errs, 0)
+
+	count := 1
+	se.scenarioExecutor = &mockExecutor{
+		executeFunc: func(i gauge.Item, r result.Result) {
+			if count < MaxRetriesCount {
+				r.SetFailure()
+			} else {
+				r.(*result.ScenarioResult).ProtoScenario.ExecutionStatus = gauge_messages.ExecutionStatus_PASSED
+			}
+
+			count++
+		},
+	}
+
+	return se
 }
 
 func TestExecuteShouldMarkSpecAsSkippedWhenAllScenariosSkipped(t *testing.T) {

--- a/filter/specItemFilter.go
+++ b/filter/specItemFilter.go
@@ -60,7 +60,7 @@ func (filter *scenarioFilterBasedOnSpan) Filter(item gauge.Item) bool {
 	return true
 }
 
-func newScenarioFilterBasedOnTags(specTags []string, tagExp string) *ScenarioFilterBasedOnTags {
+func NewScenarioFilterBasedOnTags(specTags []string, tagExp string) *ScenarioFilterBasedOnTags {
 	return &ScenarioFilterBasedOnTags{specTags, tagExp}
 }
 
@@ -215,7 +215,7 @@ func filterSpecsByTags(specs []*gauge.Specification, tagExpression string) ([]*g
 		if spec.Tags != nil {
 			tagValues = spec.Tags.Values()
 		}
-		specWithFilteredItems, specWithOtherItems := spec.Filter(newScenarioFilterBasedOnTags(tagValues, tagExpression))
+		specWithFilteredItems, specWithOtherItems := spec.Filter(NewScenarioFilterBasedOnTags(tagValues, tagExpression))
 		if len(specWithFilteredItems.Scenarios) != 0 {
 			filteredSpecs = append(filteredSpecs, specWithFilteredItems)
 		}

--- a/filter/specItemFilter_test.go
+++ b/filter/specItemFilter_test.go
@@ -602,14 +602,14 @@ func (s *MySuite) TestToFilterScenariosByTagExpWithDuplicateTagNames(c *C) {
 
 func (s *MySuite) TestFilterTags(c *C) {
 	specTags := []string{"abcd", "foo", "bar", "foo bar"}
-	tagFilter := newScenarioFilterBasedOnTags(specTags, "abcd & foo bar")
+	tagFilter := NewScenarioFilterBasedOnTags(specTags, "abcd & foo bar")
 	evaluateTrue := tagFilter.filterTags(specTags)
 	c.Assert(evaluateTrue, Equals, true)
 }
 
 func (s *MySuite) TestSanitizeTags(c *C) {
 	specTags := []string{"abcd", "foo", "bar", "foo bar"}
-	tagFilter := newScenarioFilterBasedOnTags(specTags, "abcd & foo bar | true")
+	tagFilter := NewScenarioFilterBasedOnTags(specTags, "abcd & foo bar | true")
 	evaluateTrue := tagFilter.filterTags(specTags)
 	c.Assert(evaluateTrue, Equals, true)
 }


### PR DESCRIPTION
It's kinda like feature request.

Added flag to set max retries for failed scenarios. It could be useful when we have unstable tests which depends on external conditions like internet stability or 3rd-party services.

For example, test may fails because there was bad network conditions and request took too much time.

How it will work:

**Given scenario:**
```
# Simple example

|num|
|  0|
| 10|

## Should retry if fails
* Given <num> equals to 10
```

**When execute:**
 `gauge run specs/ --max-retries-count 2`

**Then output:**
```
# Simple example

   |num|
   |---|
   |0  |
  ## Should retry if fails	 ✘
        Failed Step: Given <num> equals to 10
        Specification: specs/example.spec:8
        Error Message: AssertionError [ERR_ASSERTION]: '0' == '10'
        Stacktrace: 
        AssertionError [ERR_ASSERTION]: '0' == '10'
            at Object.<anonymous> (tests/step_implementation.js:8:10)

   |num|
   |---|
   |0  |
  ## Should retry if fails	 ✘
        Failed Step: Given <num> equals to 10
        Specification: specs/example.spec:8
        Error Message: AssertionError [ERR_ASSERTION]: '0' == '10'
        Stacktrace: 
        AssertionError [ERR_ASSERTION]: '0' == '10'
            at Object.<anonymous> (tests/step_implementation.js:8:10)

   |num|
   |---|
   |10 |
  ## Should retry if fails	 ✔

Successfully generated html-report to => /home/user/test-js/reports/html-report/index.html
Specifications:	1 executed	0 passed	1 failed	0 skipped
Scenarios:	2 executed	1 passed	1 failed	0 skipped
```