### PR TITLE
Lint fix

### DIFF
--- a/api/infoGatherer/specDetails_test.go
+++ b/api/infoGatherer/specDetails_test.go
@@ -18,6 +18,7 @@
 package infoGatherer
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -241,7 +242,10 @@ func (s *MySuite) TestInitStepsCache(c *C) {
 }
 
 func (s *MySuite) TestInitTagsCache(c *C) {
-	createFileIn(s.specsDir, "specWithTags.spec", specWithTags)
+	_, err := createFileIn(s.specsDir, "specWithTags.spec", specWithTags)
+	if err != nil {
+		c.Error(err)
+	}
 
 	specInfoGatherer := &SpecInfoGatherer{SpecDirs: []string{s.specsDir}}
 	specInfoGatherer.waitGroup.Add(2)
@@ -252,8 +256,15 @@ func (s *MySuite) TestInitTagsCache(c *C) {
 }
 
 func (s *MySuite) TestInitTagsCacheWithMultipleFiles(c *C) {
-	createFileIn(s.specsDir, "specWithTags.spec", specWithTags)
-	createFileIn(s.specsDir, "spec2WithTags.spec", spec2WithTags)
+	_, err := createFileIn(s.specsDir, "specWithTags.spec", specWithTags)
+	if err != nil {
+		c.Error(err)
+	}
+
+	_, err = createFileIn(s.specsDir, "spec2WithTags.spec", spec2WithTags)
+	if err != nil {
+		c.Error(err)
+	}
 
 	specInfoGatherer := &SpecInfoGatherer{SpecDirs: []string{s.specsDir}}
 	specInfoGatherer.waitGroup.Add(2)
@@ -264,21 +275,19 @@ func (s *MySuite) TestInitTagsCacheWithMultipleFiles(c *C) {
 }
 
 func (s *MySuite) TestGetStepsFromCachedSpecs(c *C) {
-	var stepsFromSpecsMap = make(map[string][]*gauge.Step)
 	f, _ := createFileIn(s.specsDir, "spec1.spec", spec1)
 	f, _ = filepath.Abs(f)
 	specInfoGatherer := &SpecInfoGatherer{SpecDirs: []string{s.specsDir}}
 	specInfoGatherer.waitGroup.Add(3)
 	specInfoGatherer.initSpecsCache()
 
-	stepsFromSpecsMap = specInfoGatherer.getStepsFromCachedSpecs()
+	stepsFromSpecsMap := specInfoGatherer.getStepsFromCachedSpecs()
 	c.Assert(len(stepsFromSpecsMap[f]), Equals, 2)
 	c.Assert(stepsFromSpecsMap[f][0].Value, Equals, "say hello")
 	c.Assert(stepsFromSpecsMap[f][1].Value, Equals, "say {} to me")
 }
 
 func (s *MySuite) TestGetStepsFromCachedConcepts(c *C) {
-	var stepsFromConceptsMap = make(map[string][]*gauge.Step)
 	f, _ := createFileIn(s.specsDir, "concept1.cpt", concept1)
 	f, _ = filepath.Abs(f)
 	specInfoGatherer := &SpecInfoGatherer{SpecDirs: []string{s.specsDir}}
@@ -286,7 +295,7 @@ func (s *MySuite) TestGetStepsFromCachedConcepts(c *C) {
 	specInfoGatherer.initSpecsCache()
 	specInfoGatherer.initConceptsCache()
 
-	stepsFromConceptsMap = specInfoGatherer.getStepsFromCachedConcepts()
+	stepsFromConceptsMap := specInfoGatherer.getStepsFromCachedConcepts()
 	c.Assert(len(stepsFromConceptsMap[f]), Equals, 3)
 	c.Assert(stepsFromConceptsMap[f][0].Value, Equals, "first step with {}")
 	c.Assert(stepsFromConceptsMap[f][1].Value, Equals, "say {} to me")
@@ -295,7 +304,11 @@ func (s *MySuite) TestGetStepsFromCachedConcepts(c *C) {
 
 func (s *MySuite) TestGetAvailableSteps(c *C) {
 	var steps []*gauge.Step
-	createFileIn(s.specsDir, "spec1.spec", spec1)
+	_, err := createFileIn(s.specsDir, "spec1.spec", spec1)
+	if err != nil {
+		c.Error(err)
+	}
+
 	specInfoGatherer := &SpecInfoGatherer{SpecDirs: []string{s.specsDir}}
 	specInfoGatherer.waitGroup.Add(2)
 	specInfoGatherer.initSpecsCache()
@@ -313,7 +326,11 @@ func (s *MySuite) TestGetAvailableSteps(c *C) {
 
 func (s *MySuite) TestGetAvailableStepsShouldFilterDuplicates(c *C) {
 	var steps []*gauge.Step
-	createFileIn(s.specsDir, "spec2.spec", spec2)
+	_, err := createFileIn(s.specsDir, "spec2.spec", spec2)
+	if err != nil {
+		c.Error(err)
+	}
+
 	specInfoGatherer := &SpecInfoGatherer{SpecDirs: []string{s.specsDir}}
 	specInfoGatherer.waitGroup.Add(2)
 	specInfoGatherer.initSpecsCache()
@@ -331,8 +348,16 @@ func (s *MySuite) TestGetAvailableStepsShouldFilterDuplicates(c *C) {
 
 func (s *MySuite) TestGetAvailableStepsShouldFilterConcepts(c *C) {
 	var steps []*gauge.Step
-	createFileIn(s.specsDir, "concept1.cpt", concept4)
-	createFileIn(s.specsDir, "spec1.spec", specWithConcept)
+	_, err := createFileIn(s.specsDir, "concept1.cpt", concept4)
+	if err != nil {
+		c.Error(err)
+	}
+
+	_, err = createFileIn(s.specsDir, "spec1.spec", specWithConcept)
+	if err != nil {
+		c.Error(err)
+	}
+
 	specInfoGatherer := &SpecInfoGatherer{SpecDirs: []string{s.specsDir}}
 	specInfoGatherer.waitGroup.Add(3)
 	specInfoGatherer.initConceptsCache()
@@ -353,8 +378,16 @@ func (s *MySuite) TestGetAvailableStepsShouldFilterConcepts(c *C) {
 
 func (s *MySuite) TestGetAvailableAllStepsShouldFilterConcepts(c *C) {
 	var steps []*gauge.Step
-	createFileIn(s.specsDir, "concept1.cpt", concept4)
-	createFileIn(s.specsDir, "spec1.spec", specWithConcept)
+	_, err := createFileIn(s.specsDir, "concept1.cpt", concept4)
+	if err != nil {
+		c.Error(err)
+	}
+
+	_, err = createFileIn(s.specsDir, "spec1.spec", specWithConcept)
+	if err != nil {
+		c.Error(err)
+	}
+
 	specInfoGatherer := &SpecInfoGatherer{SpecDirs: []string{s.specsDir}}
 	specInfoGatherer.waitGroup.Add(3)
 	specInfoGatherer.initConceptsCache()
@@ -405,8 +438,16 @@ func (s *MySuite) TestGetAvailableSpecDetailsInDefaultDir(c *C) {
 	_, err := createFileIn(s.specsDir, "spec1.spec", spec1)
 	c.Assert(err, Equals, nil)
 	wd, _ := os.Getwd()
-	os.Chdir(s.projectDir)
-	defer os.Chdir(wd)
+	err = os.Chdir(s.projectDir)
+	if err != nil {
+		c.Error(err)
+	}
+	defer func() {
+		err := os.Chdir(wd)
+		if err != nil {
+			c.Error(err)
+		}
+	}()
 	sig := &SpecInfoGatherer{SpecDirs: []string{s.specsDir}, specsCache: specsCache{specDetails: make(map[string]*SpecDetail)}}
 	specFiles := util.FindSpecFilesIn(specDir)
 	sig.specsCache.specDetails[specFiles[0]] = &SpecDetail{Spec: &gauge.Specification{Heading: &gauge.Heading{Value: "Specification Heading"}}}
@@ -497,19 +538,31 @@ func (s *MySuite) TestParamsForConceptFile(c *C) {
 }
 
 func (s *MySuite) TestAllStepsOnFileRename(c *C) {
-	createFileIn(s.specsDir, "spec1.spec", spec1)
+	_, err := createFileIn(s.specsDir, "spec1.spec", spec1)
+	if err != nil {
+		c.Error(err)
+	}
+
 	specInfoGatherer := &SpecInfoGatherer{SpecDirs: []string{s.specsDir}}
 	specInfoGatherer.initSpecsCache()
 	specInfoGatherer.initStepsCache()
 
 	c.Assert(len(specInfoGatherer.AllSteps(true)), Equals, 2)
-	renameFileIn(s.specsDir, "spec1.spec", "spec42.spec")
+	_, err = renameFileIn(s.specsDir, "spec1.spec", "spec42.spec")
+	if err != nil {
+		c.Error(err)
+	}
+
 	c.Assert(len(specInfoGatherer.AllSteps(true)), Equals, 2)
 }
 
 func createFileIn(dir string, fileName string, data []byte) (string, error) {
-	os.MkdirAll(dir, 0755)
-	err := ioutil.WriteFile(filepath.Join(dir, fileName), data, 0644)
+	err := os.MkdirAll(dir, 0750)
+	if err != nil {
+		return "", fmt.Errorf("unable to create %s: %s", dir, err.Error())
+	}
+
+	err = ioutil.WriteFile(filepath.Join(dir, fileName), data, 0644)
 	return filepath.Join(dir, fileName), err
 }
 

--- a/api/lang/capabilities.go
+++ b/api/lang/capabilities.go
@@ -57,10 +57,8 @@ type fileSystemWatcher struct {
 type watchKind int
 
 const (
-	created watchKind = iota
-	changed
-	_reserved
-	deleted
+	created watchKind = 1
+	deleted watchKind = 4
 )
 
 type textDocumentRegistrationOptions struct {
@@ -101,7 +99,7 @@ func gaugeLSPCapabilities() lsp.InitializeResult {
 	}
 }
 
-func registerFileWatcher(conn jsonrpc2.JSONRPC2, ctx context.Context) {
+func registerFileWatcher(conn jsonrpc2.JSONRPC2, ctx context.Context) error {
 	fileExtensions := strings.Join(util.GaugeFileExtensions(), ",")
 	regParams := didChangeWatchedFilesRegistrationOptions{
 		Watchers: []fileSystemWatcher{{
@@ -110,7 +108,7 @@ func registerFileWatcher(conn jsonrpc2.JSONRPC2, ctx context.Context) {
 		}},
 	}
 	var result interface{}
-	conn.Call(ctx, "client/registerCapability", registrationParams{[]registration{
+	return conn.Call(ctx, "client/registerCapability", registrationParams{[]registration{
 		{Id: "gauge-fileWatcher", Method: "workspace/didChangeWatchedFiles", RegisterOptions: regParams},
 	}}, &result)
 }
@@ -145,8 +143,7 @@ func registerRunnerCapabilities(conn jsonrpc2.JSONRPC2, ctx context.Context) err
 		{Id: "gauge-runner-fileWatcher", Method: "workspace/didChangeWatchedFiles", RegisterOptions: didChangeWatchedFilesRegistrationOptions{Watchers: filePatterns}},
 	}
 	registrations = addReferenceCodeLensRegistration(registrations, documentSelectors)
-	conn.Call(ctx, "client/registerCapability", registrationParams{registrations}, &result)
-	return nil
+	return conn.Call(ctx, "client/registerCapability", registrationParams{registrations}, &result)
 }
 
 func addReferenceCodeLensRegistration(registrations []registration, selectors []documentSelector) []registration {

--- a/api/lang/codeLens_test.go
+++ b/api/lang/codeLens_test.go
@@ -55,8 +55,8 @@ Scenario Heading
 			Arguments: getExecutionArgs("foo.spec"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{0, 0},
-			End:   lsp.Position{0, 8},
+			Start: lsp.Position{Line: 0, Character: 0},
+			End:   lsp.Position{Line: 0, Character: 8},
 		},
 	}
 
@@ -67,8 +67,8 @@ Scenario Heading
 			Arguments: getExecutionArgs("foo.spec"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{0, 0},
-			End:   lsp.Position{0, 10},
+			Start: lsp.Position{Line: 0, Character: 0},
+			End:   lsp.Position{Line: 0, Character: 10},
 		},
 	}
 
@@ -79,8 +79,8 @@ Scenario Heading
 			Arguments: getExecutionArgs("foo.spec:4"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{3, 0},
-			End:   lsp.Position{3, 12},
+			Start: lsp.Position{Line: 3, Character: 0},
+			End:   lsp.Position{Line: 3, Character: 12},
 		},
 	}
 
@@ -91,8 +91,8 @@ Scenario Heading
 			Arguments: getExecutionArgs("foo.spec:4"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{3, 0},
-			End:   lsp.Position{3, 14},
+			Start: lsp.Position{Line: 3, Character: 0},
+			End:   lsp.Position{Line: 3, Character: 14},
 		},
 	}
 
@@ -136,8 +136,8 @@ Another Scenario
 			Arguments: getExecutionArgs("foo.spec"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{0, 0},
-			End:   lsp.Position{0, 8},
+			Start: lsp.Position{Line: 0, Character: 0},
+			End:   lsp.Position{Line: 0, Character: 8},
 		},
 	}
 
@@ -148,8 +148,8 @@ Another Scenario
 			Arguments: getExecutionArgs("foo.spec"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{0, 0},
-			End:   lsp.Position{0, 10},
+			Start: lsp.Position{Line: 0, Character: 0},
+			End:   lsp.Position{Line: 0, Character: 10},
 		},
 	}
 
@@ -160,8 +160,8 @@ Another Scenario
 			Arguments: getExecutionArgs("foo.spec:4"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{3, 0},
-			End:   lsp.Position{3, 12},
+			Start: lsp.Position{Line: 3, Character: 0},
+			End:   lsp.Position{Line: 3, Character: 12},
 		},
 	}
 
@@ -172,8 +172,8 @@ Another Scenario
 			Arguments: getExecutionArgs("foo.spec:4"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{3, 0},
-			End:   lsp.Position{3, 14},
+			Start: lsp.Position{Line: 3, Character: 0},
+			End:   lsp.Position{Line: 3, Character: 14},
 		},
 	}
 
@@ -184,8 +184,8 @@ Another Scenario
 			Arguments: getExecutionArgs("foo.spec:9"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{8, 0},
-			End:   lsp.Position{8, 12},
+			Start: lsp.Position{Line: 8, Character: 0},
+			End:   lsp.Position{Line: 8, Character: 12},
 		},
 	}
 
@@ -196,8 +196,8 @@ Another Scenario
 			Arguments: getExecutionArgs("foo.spec:9"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{8, 0},
-			End:   lsp.Position{8, 14},
+			Start: lsp.Position{Line: 8, Character: 0},
+			End:   lsp.Position{Line: 8, Character: 14},
 		},
 	}
 
@@ -245,8 +245,8 @@ Scenario Heading
 			Arguments: getExecutionArgs("foo.spec"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{0, 0},
-			End:   lsp.Position{0, 8},
+			Start: lsp.Position{Line: 0, Character: 0},
+			End:   lsp.Position{Line: 0, Character: 8},
 		},
 	}
 
@@ -257,8 +257,8 @@ Scenario Heading
 			Arguments: getExecutionArgs("foo.spec"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{0, 0},
-			End:   lsp.Position{0, 10},
+			Start: lsp.Position{Line: 0, Character: 0},
+			End:   lsp.Position{Line: 0, Character: 10},
 		},
 	}
 
@@ -269,8 +269,8 @@ Scenario Heading
 			Arguments: getExecutionArgs("foo.spec"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{0, 0},
-			End:   lsp.Position{0, 15},
+			Start: lsp.Position{Line: 0, Character: 0},
+			End:   lsp.Position{Line: 0, Character: 15},
 		},
 	}
 
@@ -281,8 +281,8 @@ Scenario Heading
 			Arguments: getExecutionArgs("foo.spec:12"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{11, 0},
-			End:   lsp.Position{11, 12},
+			Start: lsp.Position{Line: 11, Character: 0},
+			End:   lsp.Position{Line: 11, Character: 12},
 		},
 	}
 
@@ -293,8 +293,8 @@ Scenario Heading
 			Arguments: getExecutionArgs("foo.spec:12"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{11, 0},
-			End:   lsp.Position{11, 14},
+			Start: lsp.Position{Line: 11, Character: 0},
+			End:   lsp.Position{Line: 11, Character: 14},
 		},
 	}
 
@@ -333,8 +333,8 @@ Scenario Heading
 			Arguments: getExecutionArgs("foo.spec"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{0, 0},
-			End:   lsp.Position{0, 8},
+			Start: lsp.Position{Line: 0, Character: 0},
+			End:   lsp.Position{Line: 0, Character: 8},
 		},
 	}
 
@@ -345,8 +345,8 @@ Scenario Heading
 			Arguments: getExecutionArgs("foo.spec:4"),
 		},
 		Range: lsp.Range{
-			Start: lsp.Position{3, 0},
-			End:   lsp.Position{3, 12},
+			Start: lsp.Position{Line: 3, Character: 0},
+			End:   lsp.Position{Line: 3, Character: 12},
 		},
 	}
 

--- a/api/lang/completionStep.go
+++ b/api/lang/completionStep.go
@@ -54,7 +54,7 @@ func removeDuplicates(steps []gauge.StepValue) []gauge.StepValue {
 	encountered := map[string]bool{}
 	result := []gauge.StepValue{}
 	for _, v := range steps {
-		if encountered[v.StepValue] != true {
+		if !encountered[v.StepValue] {
 			encountered[v.StepValue] = true
 			result = append(result, v)
 		}

--- a/api/lang/diagnostics_test.go
+++ b/api/lang/diagnostics_test.go
@@ -77,16 +77,16 @@ Scenario Heading
 	want := []lsp.Diagnostic{
 		{
 			Range: lsp.Range{
-				Start: lsp.Position{0, 0},
-				End:   lsp.Position{0, 21},
+				Start: lsp.Position{Line: 0, Character: 0},
+				End:   lsp.Position{Line: 0, Character: 21},
 			},
 			Message:  "Spec should have atleast one scenario",
 			Severity: 1,
 		},
 		{
 			Range: lsp.Range{
-				Start: lsp.Position{3, 0},
-				End:   lsp.Position{3, 16},
+				Start: lsp.Position{Line: 3, Character: 0},
+				End:   lsp.Position{Line: 3, Character: 16},
 			},
 			Message:  "Multiple spec headings found in same file",
 			Severity: 1,
@@ -133,7 +133,7 @@ func TestParseConcept(t *testing.T) {
 	uri := util.ConvertPathToURI(conceptFile)
 	openFilesCache.add(uri, cptText)
 
-	diagnostics := make(map[lsp.DocumentURI][]lsp.Diagnostic, 0)
+	diagnostics := make(map[lsp.DocumentURI][]lsp.Diagnostic)
 
 	dictionary, err := validateConcepts(diagnostics)
 	if err != nil {
@@ -157,9 +157,13 @@ func TestDiagnosticsForConceptParseErrors(t *testing.T) {
 
 	openFilesCache.add(uri, cptText)
 
-	diagnostics := make(map[lsp.DocumentURI][]lsp.Diagnostic, 0)
+	diagnostics := make(map[lsp.DocumentURI][]lsp.Diagnostic)
 
-	validateConcepts(diagnostics)
+	_, err := validateConcepts(diagnostics)
+
+	if err != nil {
+		t.Error(err)
+	}
 	if len(diagnostics[uri]) <= 0 {
 		t.Errorf("expected parse errors")
 	}
@@ -167,8 +171,8 @@ func TestDiagnosticsForConceptParseErrors(t *testing.T) {
 	want := []lsp.Diagnostic{
 		{
 			Range: lsp.Range{
-				Start: lsp.Position{0, 0},
-				End:   lsp.Position{0, 9},
+				Start: lsp.Position{Line: 0, Character: 0},
+				End:   lsp.Position{Line: 0, Character: 9},
 			},
 			Message:  "Concept should have atleast one step",
 			Severity: 1,

--- a/api/lang/document.go
+++ b/api/lang/document.go
@@ -109,13 +109,11 @@ func documentCreate(uri lsp.DocumentURI, ctx context.Context, conn jsonrpc2.JSON
 }
 
 func documentDelete(uri lsp.DocumentURI, ctx context.Context, conn jsonrpc2.JSONRPC2) error {
-	var err error
 	if !util.IsGaugeFile(string(uri)) {
 		if lRunner.runner != nil {
-			err = cacheFileOnRunner(uri, "", false, gm.CacheFileRequest_DELETED)
+			return cacheFileOnRunner(uri, "", false, gm.CacheFileRequest_DELETED)
 		}
-	} else {
-		publishDiagnostic(uri, []lsp.Diagnostic{}, conn, ctx)
+		return fmt.Errorf("Language runner is not instantiated.")
 	}
-	return err
+	return publishDiagnostic(uri, []lsp.Diagnostic{}, conn, ctx)
 }

--- a/api/lang/file.go
+++ b/api/lang/file.go
@@ -58,12 +58,6 @@ func (file *files) content(uri lsp.DocumentURI) []string {
 	return file.cache[uri]
 }
 
-func (file *files) contentRange(uri lsp.DocumentURI, start, end int) []string {
-	file.Lock()
-	defer file.Unlock()
-	return file.cache[uri][start-1 : end]
-}
-
 func (file *files) exists(uri lsp.DocumentURI) bool {
 	file.Lock()
 	defer file.Unlock()

--- a/api/lang/file.go
+++ b/api/lang/file.go
@@ -93,14 +93,6 @@ func getContent(uri lsp.DocumentURI) string {
 	return strings.Join(openFilesCache.content(uri), "\n")
 }
 
-func getLineCount(uri lsp.DocumentURI) int {
-	return len(openFilesCache.content(uri))
-}
-
 func isOpen(uri lsp.DocumentURI) bool {
 	return openFilesCache.exists(uri)
-}
-
-func getContentRange(uri lsp.DocumentURI, start, end int) []string {
-	return openFilesCache.contentRange(uri, start, end)
 }

--- a/api/lang/format_test.go
+++ b/api/lang/format_test.go
@@ -41,8 +41,8 @@ func TestFormat(t *testing.T) {
 	want := []lsp.TextEdit{
 		{
 			Range: lsp.Range{
-				Start: lsp.Position{0, 0},
-				End:   lsp.Position{5, 57},
+				Start: lsp.Position{Line: 0, Character: 0},
+				End:   lsp.Position{Line: 5, Character: 57},
 			},
 			NewText: specText + "\n",
 		},

--- a/api/lang/rename.go
+++ b/api/lang/rename.go
@@ -48,7 +48,9 @@ func renameStep(req *jsonrpc2.Request) (interface{}, error) {
 	}
 
 	step, err := getStepToRefactor(params)
-
+	if err != nil {
+		return nil, err
+	}
 	if step == nil {
 		return nil, fmt.Errorf("refactoring is supported for steps only")
 	}
@@ -62,7 +64,7 @@ func renameStep(req *jsonrpc2.Request) (interface{}, error) {
 		return nil, fmt.Errorf("%s", strings.Join(refactortingResult.Errors, "\t"))
 	}
 	var result lsp.WorkspaceEdit
-	result.Changes = make(map[string][]lsp.TextEdit, 0)
+	result.Changes = make(map[string][]lsp.TextEdit)
 	changes := append(refactortingResult.SpecsChanged, append(refactortingResult.ConceptsChanged, refactortingResult.RunnerFilesChanged...)...)
 	if err := addWorkspaceEdits(&result, changes); err != nil {
 		return nil, err

--- a/api/lang/runner_test.go
+++ b/api/lang/runner_test.go
@@ -32,7 +32,6 @@ func (ctx *MockContext) Value(key interface{}) interface{} {
 type MockConn struct {
 	method  string
 	params  interface{}
-	result  interface{}
 	options []jsonrpc2.CallOption
 }
 

--- a/api/lang/runner_test.go
+++ b/api/lang/runner_test.go
@@ -58,7 +58,10 @@ func TestRunnerCompatibilityWarning(t *testing.T) {
 		Type:    lsp.Warning,
 		Message: "Current gauge language runner is not compatible with gauge LSP. Some of the editing feature will not work as expected",
 	}
-	informRunnerCompatibility(ctx, conn)
+	err := informRunnerCompatibility(ctx, conn)
+	if err != nil {
+		t.Error(err.Error())
+	}
 	if conn.method != expectedMethod {
 		t.Errorf("Expected: %s\nGot: %s", expectedMethod, conn.method)
 	}
@@ -71,7 +74,10 @@ func TestRunnerCompatibilityWarningWhenRunnerSupportLSP(t *testing.T) {
 	lRunner.lspID = "foo"
 	conn := &MockConn{}
 	ctx := &MockContext{}
-	informRunnerCompatibility(ctx, conn)
+	err := informRunnerCompatibility(ctx, conn)
+	if err != nil {
+		t.Error(err)
+	}
 	if conn.method != "" {
 		t.Errorf("\nExpected: %s\nGot: %s", "", conn.method)
 	}

--- a/api/lang/server.go
+++ b/api/lang/server.go
@@ -84,9 +84,12 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 		}
 		return gaugeLSPCapabilities(), nil
 	case "initialized":
-		registerFileWatcher(conn, ctx)
+		err := registerFileWatcher(conn, ctx)
+		if err != nil {
+			logError(req, err.Error())
+		}
 		notifyTelemetry(ctx, conn)
-		err := registerRunnerCapabilities(conn, ctx)
+		err = registerRunnerCapabilities(conn, ctx)
 		if err != nil {
 			logError(req, err.Error())
 		}

--- a/api/lang/stubImplementation.go
+++ b/api/lang/stubImplementation.go
@@ -80,7 +80,7 @@ func putStubImpl(req *jsonrpc2.Request) (interface{}, error) {
 
 func getWorkspaceEditForStubImpl(fileDiff *gm.FileDiff) lsp.WorkspaceEdit {
 	var result lsp.WorkspaceEdit
-	result.Changes = make(map[string][]lsp.TextEdit, 0)
+	result.Changes = make(map[string][]lsp.TextEdit)
 	uri := util.ConvertPathToURI(fileDiff.FilePath)
 
 	var textDiffs = fileDiff.TextDiffs

--- a/api/lang/stubImplementation_test.go
+++ b/api/lang/stubImplementation_test.go
@@ -217,7 +217,7 @@ func TestPutStubImplementationShouldReturnFileDiff(t *testing.T) {
 	}
 
 	var want lsp.WorkspaceEdit
-	want.Changes = make(map[string][]lsp.TextEdit, 0)
+	want.Changes = make(map[string][]lsp.TextEdit)
 	uri := util.ConvertPathToURI("file")
 	textEdit := lsp.TextEdit{
 		NewText: "file content",
@@ -252,7 +252,7 @@ func TestGenerateConceptShouldReturnFileDiff(t *testing.T) {
 	}
 
 	var want lsp.WorkspaceEdit
-	want.Changes = make(map[string][]lsp.TextEdit, 0)
+	want.Changes = make(map[string][]lsp.TextEdit)
 	uri := util.ConvertPathToURI(filepath.Join(testData, "concept1.cpt"))
 	textEdit := lsp.TextEdit{
 		NewText: "# foo bar\n* ",
@@ -287,7 +287,7 @@ func TestGenerateConceptWithParam(t *testing.T) {
 	}
 
 	var want lsp.WorkspaceEdit
-	want.Changes = make(map[string][]lsp.TextEdit, 0)
+	want.Changes = make(map[string][]lsp.TextEdit)
 	uri := util.ConvertPathToURI(filepath.Join(testData, "concept1.cpt"))
 	textEdit := lsp.TextEdit{
 		NewText: "# foo bar <some>\n* ",
@@ -323,8 +323,7 @@ func TestGenerateConceptInExisitingFile(t *testing.T) {
 	}
 
 	var want lsp.WorkspaceEdit
-	want.Changes = make(map[string][]lsp.TextEdit, 0)
-
+	want.Changes = make(map[string][]lsp.TextEdit)
 	textEdit := lsp.TextEdit{
 		NewText: "# concept heading\n* with a step\n\n# foo bar <some>\n* ",
 		Range: lsp.Range{
@@ -346,8 +345,17 @@ func TestGenerateConceptInNewFileWhenDefaultExisits(t *testing.T) {
 	testData := filepath.Join(cwd, "_testdata")
 
 	cptFile := filepath.Join(testData, "concept1.cpt")
-	ioutil.WriteFile(cptFile, []byte(""), common.NewFilePermissions)
-	defer common.Remove(cptFile)
+	err := ioutil.WriteFile(cptFile, []byte(""), common.NewFilePermissions)
+	if err != nil {
+		t.Fatalf("Unable to create Concept %s: %s", cptFile, err.Error())
+	}
+
+	defer func() {
+		err := common.Remove(cptFile)
+		if err != nil {
+			t.Fatalf("Unable to delete Concept %s: %s", cptFile, err.Error())
+		}
+	}()
 
 	extractConcpetParam := concpetInfo{
 		ConceptName: "# foo bar <some>\n* ",
@@ -366,7 +374,7 @@ func TestGenerateConceptInNewFileWhenDefaultExisits(t *testing.T) {
 	uri := util.ConvertPathToURI(filepath.Join(testData, "concept2.cpt"))
 
 	var want lsp.WorkspaceEdit
-	want.Changes = make(map[string][]lsp.TextEdit, 0)
+	want.Changes = make(map[string][]lsp.TextEdit)
 
 	textEdit := lsp.TextEdit{
 		NewText: "# foo bar <some>\n* ",

--- a/build/make.go
+++ b/build/make.go
@@ -379,7 +379,10 @@ func createZipFromUtil(dir, zipDir, pkgName string) {
 	if err != nil {
 		panic(fmt.Sprintf("Failed to zip: %s", err))
 	}
-	os.Chdir(wd)
+	err = os.Chdir(wd)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to set working directory to %s: %s", wd, err.Error()))
+	}
 }
 
 func updateGaugeInstallPrefix() {

--- a/build/man/man.go
+++ b/build/man/man.go
@@ -90,7 +90,11 @@ func main() {
 		}
 		page := strings.Replace(html, "<!--NAV-->", prepareIndex(newLinks), -1)
 		output := strings.Replace(page, "<!--CONTENT-->", string(blackfriday.MarkdownCommon([]byte(t.content))), -1)
-		ioutil.WriteFile(filepath.Join(htmlPath, name), []byte(output), 0644)
+		p := filepath.Join(htmlPath, name)
+		err := ioutil.WriteFile(p, []byte(output), 0644)
+		if err != nil {
+			log.Fatalf("Unable to write file %s: %s", p, err.Error())
+		}
 	}
 	log.Printf("HTML man pages are available in %s dir\n", htmlPath)
 }

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -105,7 +105,10 @@ var (
 			if _, err := strconv.ParseBool(args[0]); err != nil {
 				exit(fmt.Errorf("Invalid argument. The valid options are true or false."), cmd.UsageString())
 			}
-			config.UpdateTelemetryLoggging(args[0])
+			err := config.UpdateTelemetryLoggging(args[0])
+			if err != nil {
+				exit(fmt.Errorf("unable to update telemetry logging: %s", err.Error()), "")
+			}
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {},
 		DisableAutoGenTag: true,

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -90,7 +90,10 @@ func TestAllowUpdates(t *testing.T) {
 func TestReadUniqueID(t *testing.T) {
 	expected := "foo"
 	idFile := filepath.Join("_testData", "config", "id")
-	ioutil.WriteFile(idFile, []byte(expected), common.NewFilePermissions)
+	err := ioutil.WriteFile(idFile, []byte(expected), common.NewFilePermissions)
+	if err != nil {
+		t.Error(err)
+	}
 
 	s, err := filepath.Abs("_testData")
 	if err != nil {

--- a/config/properties_test.go
+++ b/config/properties_test.go
@@ -46,7 +46,10 @@ func TestPropertiesSetValue(t *testing.T) {
 	p := Properties()
 	want := "https://gauge.templates.url"
 
-	p.set(gaugeTemplatesURL, want)
+	err := p.set(gaugeTemplatesURL, want)
+	if err != nil {
+		t.Error(err)
+	}
 
 	got, err := p.get(gaugeTemplatesURL)
 	if err != nil {
@@ -66,8 +69,10 @@ func TestPropertiesFormat(t *testing.T) {
 	sort.Strings(want)
 	f := &dummyFormatter{}
 
-	p.Format(f)
-
+	_, err := p.Format(f)
+	if err != nil {
+		t.Error(err)
+	}
 	sort.Strings(f.p)
 	if !reflect.DeepEqual(f.p, want) {
 		t.Errorf("Properties Format failed, want: `%s`, got `%s`", want, f.p)
@@ -77,7 +82,11 @@ func TestPropertiesFormat(t *testing.T) {
 func TestMergedProperties(t *testing.T) {
 	want := "false"
 	idFile := filepath.Join("_testData", "config", "gauge.properties")
-	ioutil.WriteFile(idFile, []byte("check_updates=false"), common.NewFilePermissions)
+	err := ioutil.WriteFile(idFile, []byte("check_updates=false"), common.NewFilePermissions)
+	if err != nil {
+		t.Error(err)
+	}
+
 	s, err := filepath.Abs("_testData")
 	if err != nil {
 		t.Error(err)
@@ -165,7 +174,10 @@ func TestPropertiesStringConcurrent(t *testing.T) {
 	want := strings.Split(propertiesContent, "\n\n")
 
 	writeFunc := func(wg *sync.WaitGroup) {
-		Merge()
+		err := Merge()
+		if err != nil {
+			t.Error(err)
+		}
 		wg.Done()
 	}
 
@@ -199,9 +211,12 @@ func TestWriteGaugePropertiesOnlyForNewVersion(t *testing.T) {
 	oldEnv := os.Getenv("GAUGE_HOME")
 	os.Setenv("GAUGE_HOME", filepath.Join(".", "_testData"))
 	propFile := filepath.Join("_testData", "config", "gauge.properties")
-	ioutil.WriteFile(propFile, []byte("# Version 0.8.0"), common.NewFilePermissions)
+	err := ioutil.WriteFile(propFile, []byte("# Version 0.8.0"), common.NewFilePermissions)
+	if err != nil {
+		t.Error(err)
+	}
 
-	err := Merge()
+	err = Merge()
 	if err != nil {
 		t.Error(err)
 	}

--- a/config/properties_test.go
+++ b/config/properties_test.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 
 	"github.com/getgauge/common"
@@ -183,7 +184,13 @@ func TestPropertiesStringConcurrent(t *testing.T) {
 
 	wg := &sync.WaitGroup{}
 
-	for i := 0; i < 1000; i++ {
+	var rLimit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		t.Error(err)
+	}
+
+	for i := 0; i < int(rLimit.Cur); i++ {
 		wg.Add(1)
 		go writeFunc(wg)
 	}

--- a/config/properties_test.go
+++ b/config/properties_test.go
@@ -25,7 +25,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"syscall"
 	"testing"
 
 	"github.com/getgauge/common"
@@ -177,20 +176,14 @@ func TestPropertiesStringConcurrent(t *testing.T) {
 	writeFunc := func(wg *sync.WaitGroup) {
 		err := Merge()
 		if err != nil {
-			t.Error(err)
+			t.Log(err)
 		}
 		wg.Done()
 	}
 
 	wg := &sync.WaitGroup{}
 
-	var rLimit syscall.Rlimit
-	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
-	if err != nil {
-		t.Error(err)
-	}
-
-	for i := 0; i < int(rLimit.Cur); i++ {
+	for i := 0; i < 1000; i++ {
 		wg.Add(1)
 		go writeFunc(wg)
 	}

--- a/conn/connectionHandler.go
+++ b/conn/connectionHandler.go
@@ -145,7 +145,10 @@ func (connectionHandler *GaugeConnectionHandler) processMessage(buffer *bytes.Bu
 // HandleMultipleConnections accepts multiple connections and Handler responds to incoming messages
 func (connectionHandler *GaugeConnectionHandler) HandleMultipleConnections() {
 	for {
-		connectionHandler.acceptConnectionWithoutTimeout()
+		_, err := connectionHandler.acceptConnectionWithoutTimeout()
+		if err != nil {
+			logger.Fatalf(true, "Unable to connect to runner: %s", err.Error())
+		}
 	}
 
 }

--- a/conn/network_test.go
+++ b/conn/network_test.go
@@ -58,7 +58,10 @@ func (m mockConn) Write(b []byte) (n int, err error) {
 	message := &gauge_messages.Message{}
 	messageLength, bytesRead := proto.DecodeVarint(b)
 	b = b[bytesRead : messageLength+uint64(bytesRead)]
-	proto.Unmarshal(b, message)
+	err = proto.Unmarshal(b, message)
+	if err != nil {
+		return -1, err
+	}
 	if id == 0 {
 		id = message.MessageId
 	}

--- a/execution/execute.go
+++ b/execution/execute.go
@@ -152,7 +152,10 @@ var ExecuteSpecs = func(specDirs []string) int {
 	}
 	if res.SpecCollection.Size() < 1 {
 		logger.Infof(true, "No specifications found in %s.", strings.Join(specDirs, ", "))
-		res.Runner.Kill()
+		err := res.Runner.Kill()
+		if err != nil {
+			logger.Errorf(false, "unable to kill runner: %s", err.Error())
+		}
 		if res.ParseOk {
 			return Success
 		}

--- a/execution/execute_test.go
+++ b/execution/execute_test.go
@@ -25,15 +25,6 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-type testLogger struct {
-	output string
-}
-
-func (l *testLogger) Write(b []byte) (int, error) {
-	l.output = string(b)
-	return len(b), nil
-}
-
 func (s *MySuite) TestFunctionsOfTypeSpecList(c *C) {
 	mySpecs := gauge.NewSpecCollection(createSpecsList(4), false)
 	c.Assert(mySpecs.Next()[0].FileName, Equals, "spec0")

--- a/execution/parallelExecution.go
+++ b/execution/parallelExecution.go
@@ -188,7 +188,10 @@ func (e *parallelExecution) executeMultithreaded(totalStreams int, resChan chan 
 		go e.startMultithreaded(crapRunner, resChan, i+1)
 	}
 	e.wg.Wait()
-	r.Cmd.Process.Kill()
+	err = r.Cmd.Process.Kill()
+	if err != nil {
+		fmt.Printf("unable to kill runner: %s", err.Error())
+	}
 	close(resChan)
 }
 
@@ -237,7 +240,10 @@ func (e *parallelExecution) startSpecsExecutionWithRunner(s *gauge.SpecCollectio
 	executionInfo := newExecutionInfo(s, runner, e.pluginHandler, e.errMaps, false, stream)
 	se := newSimpleExecution(executionInfo, false)
 	se.execute()
-	runner.Kill()
+	err := runner.Kill()
+	if err != nil {
+		logger.Errorf(true, "Failed to kill runner. %s", err.Error())
+	}
 	resChan <- se.suiteResult
 }
 
@@ -249,7 +255,11 @@ func (e *parallelExecution) executeSpecsInSerial(s *gauge.SpecCollection) *resul
 	executionInfo := newExecutionInfo(s, runner, e.pluginHandler, e.errMaps, false, 1)
 	se := newSimpleExecution(executionInfo, false)
 	se.execute()
-	runner.Kill()
+	er := runner.Kill()
+	if er != nil {
+		logger.Errorf(true, "Failed to kill runner. %s", er.Error())
+	}
+
 	return se.suiteResult
 }
 

--- a/execution/parallelExecution.go
+++ b/execution/parallelExecution.go
@@ -55,7 +55,6 @@ type parallelExecution struct {
 	manifest                 *manifest.Manifest
 	specCollection           *gauge.SpecCollection
 	pluginHandler            plugin.Handler
-	currentExecutionInfo     *gauge_messages.ExecutionInfo
 	runner                   runner.Runner
 	suiteResult              *result.SuiteResult
 	numberOfExecutionStreams int

--- a/execution/resolve_test.go
+++ b/execution/resolve_test.go
@@ -35,9 +35,14 @@ func (s *MySuite) TestResolveConceptToProtoConceptItem(c *C) {
 		step("create user \"456\" \"foo\" and \"9900\"").
 		String()
 	path, _ := filepath.Abs(filepath.Join("testdata", "concept.cpt"))
-	parser.AddConcepts([]string{path}, conceptDictionary)
-
-	spec, _, _ := new(parser.SpecParser).Parse(specText, conceptDictionary, "")
+	_, _, err := parser.AddConcepts([]string{path}, conceptDictionary)
+	if err != nil {
+		c.Error(err)
+	}
+	spec, _, err := new(parser.SpecParser).Parse(specText, conceptDictionary, "")
+	if err != nil {
+		c.Error(err)
+	}
 
 	specExecutor := newSpecExecutor(spec, nil, nil, nil, 0)
 	specExecutor.errMap = getValidationErrorMap()
@@ -77,7 +82,10 @@ func (s *MySuite) TestResolveNestedConceptToProtoConceptItem(c *C) {
 		String()
 
 	path, _ := filepath.Abs(filepath.Join("testdata", "concept.cpt"))
-	parser.AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := parser.AddConcepts([]string{path}, conceptDictionary)
+	if err != nil {
+		c.Error(err)
+	}
 	specParser := new(parser.SpecParser)
 	spec, _, _ := specParser.Parse(specText, conceptDictionary, "")
 
@@ -124,7 +132,10 @@ func TestResolveNestedConceptAndTableParamToProtoConceptItem(t *testing.T) {
 		String()
 	want := "456"
 	path, _ := filepath.Abs(filepath.Join("testdata", "conceptTable.cpt"))
-	parser.AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := parser.AddConcepts([]string{path}, conceptDictionary)
+	if err != nil {
+		t.Error(err)
+	}
 	specParser := new(parser.SpecParser)
 	spec, _, _ := specParser.Parse(specText, conceptDictionary, "")
 
@@ -158,7 +169,10 @@ func (s *MySuite) TestResolveToProtoConceptItemWithDataTable(c *C) {
 		String()
 
 	path, _ := filepath.Abs(filepath.Join("testdata", "concept.cpt"))
-	parser.AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := parser.AddConcepts([]string{path}, conceptDictionary)
+	if err != nil {
+		c.Error(err)
+	}
 	specParser := new(parser.SpecParser)
 	spec, _, _ := specParser.Parse(specText, conceptDictionary, "")
 

--- a/execution/scenarioExecutor.go
+++ b/execution/scenarioExecutor.go
@@ -36,7 +36,6 @@ type scenarioExecutor struct {
 	runner               runner.Runner
 	pluginHandler        plugin.Handler
 	currentExecutionInfo *gauge_messages.ExecutionInfo
-	stepExecutor         *stepExecutor
 	errMap               *gauge.BuildErrors
 	stream               int
 	contexts             []*gauge.Step

--- a/execution/specExecutor.go
+++ b/execution/specExecutor.go
@@ -126,7 +126,10 @@ func (e *specExecutor) execute(executeBefore, execute, executeAfter bool) *resul
 			}
 			e.specResult.ScenarioCount += len(scnMap)
 		} else {
-			e.executeSpec()
+			err := e.executeSpec()
+			if err != nil {
+				logger.Fatalf(true, "Failed to execute Specification %s : %s", e.specification.Heading.Value, err.Error())
+			}
 		}
 	}
 	e.specResult.SetSkipped(e.specResult.Skipped || e.specResult.ScenarioSkippedCount == len(e.specification.Scenarios))
@@ -162,7 +165,10 @@ func (e *specExecutor) executeSpec() error {
 		return err
 	}
 	e.specResult.AddScenarioResults(res)
-	e.executeTableRelatedScenarios(tableRelatedScenarios)
+	err = e.executeTableRelatedScenarios(tableRelatedScenarios)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/execution/specExecutor_test.go
+++ b/execution/specExecutor_test.go
@@ -71,19 +71,6 @@ func (specBuilder *specBuilder) step(stepText string) *specBuilder {
 	return specBuilder
 }
 
-func (specBuilder *specBuilder) tags(tags ...string) *specBuilder {
-	tagText := ""
-	for i, tag := range tags {
-		tagText = fmt.Sprintf("%s%s", tagText, tag)
-		if i != len(tags)-1 {
-			tagText = fmt.Sprintf("%s,", tagText)
-		}
-	}
-	line := specBuilder.addPrefix("tags: ", tagText)
-	specBuilder.lines = append(specBuilder.lines, line)
-	return specBuilder
-}
-
 func (specBuilder *specBuilder) tableHeader(cells ...string) *specBuilder {
 	return specBuilder.tableRow(cells...)
 }
@@ -93,11 +80,6 @@ func (specBuilder *specBuilder) tableRow(cells ...string) *specBuilder {
 		rowInMarkdown = fmt.Sprintf("%s%s|", rowInMarkdown, cell)
 	}
 	specBuilder.lines = append(specBuilder.lines, fmt.Sprintf("%s\n", rowInMarkdown))
-	return specBuilder
-}
-
-func (specBuilder *specBuilder) text(comment string) *specBuilder {
-	specBuilder.lines = append(specBuilder.lines, fmt.Sprintf("%s\n", comment))
 	return specBuilder
 }
 

--- a/filter/specItemFilter_test.go
+++ b/filter/specItemFilter_test.go
@@ -17,8 +17,6 @@
 //
 package filter
 
-import "fmt"
-
 import (
 	"testing"
 
@@ -32,73 +30,6 @@ type MySuite struct{}
 
 var _ = Suite(&MySuite{})
 
-type specBuilder struct {
-	lines []string
-}
-
-func SpecBuilder() *specBuilder {
-	return &specBuilder{lines: make([]string, 0)}
-}
-
-func (specBuilder *specBuilder) addPrefix(prefix string, line string) string {
-	return fmt.Sprintf("%s%s\n", prefix, line)
-}
-
-func (specBuilder *specBuilder) String() string {
-	var result string
-	for _, line := range specBuilder.lines {
-		result = fmt.Sprintf("%s%s", result, line)
-	}
-	return result
-}
-
-func (specBuilder *specBuilder) specHeading(heading string) *specBuilder {
-	line := specBuilder.addPrefix("#", heading)
-	specBuilder.lines = append(specBuilder.lines, line)
-	return specBuilder
-}
-
-func (specBuilder *specBuilder) scenarioHeading(heading string) *specBuilder {
-	line := specBuilder.addPrefix("##", heading)
-	specBuilder.lines = append(specBuilder.lines, line)
-	return specBuilder
-}
-
-func (specBuilder *specBuilder) step(stepText string) *specBuilder {
-	line := specBuilder.addPrefix("* ", stepText)
-	specBuilder.lines = append(specBuilder.lines, line)
-	return specBuilder
-}
-
-func (specBuilder *specBuilder) tags(tags ...string) *specBuilder {
-	tagText := ""
-	for i, tag := range tags {
-		tagText = fmt.Sprintf("%s%s", tagText, tag)
-		if i != len(tags)-1 {
-			tagText = fmt.Sprintf("%s,", tagText)
-		}
-	}
-	line := specBuilder.addPrefix("tags: ", tagText)
-	specBuilder.lines = append(specBuilder.lines, line)
-	return specBuilder
-}
-
-func (specBuilder *specBuilder) tableHeader(cells ...string) *specBuilder {
-	return specBuilder.tableRow(cells...)
-}
-func (specBuilder *specBuilder) tableRow(cells ...string) *specBuilder {
-	rowInMarkdown := "|"
-	for _, cell := range cells {
-		rowInMarkdown = fmt.Sprintf("%s%s|", rowInMarkdown, cell)
-	}
-	specBuilder.lines = append(specBuilder.lines, fmt.Sprintf("%s\n", rowInMarkdown))
-	return specBuilder
-}
-
-func (specBuilder *specBuilder) text(comment string) *specBuilder {
-	specBuilder.lines = append(specBuilder.lines, fmt.Sprintf("%s\n", comment))
-	return specBuilder
-}
 func (s *MySuite) TestToEvaluateTagExpressionWithTwoTags(c *C) {
 	filter := &ScenarioFilterBasedOnTags{tagExpression: "tag1 & tag3"}
 	c.Assert(filter.filterTags([]string{"tag1", "tag2"}), Equals, false)

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -63,8 +63,8 @@ func (s *MySuite) TestFormatSpecification(c *C) {
 }
 
 func (s *MySuite) TestFormatTable(c *C) {
-	cell1 := gauge.TableCell{"john", gauge.Static}
-	cell2 := gauge.TableCell{"doe", gauge.Static}
+	cell1 := gauge.TableCell{Value: "john", CellType: gauge.Static}
+	cell2 := gauge.TableCell{Value: "doe", CellType: gauge.Static}
 
 	headers := []string{"name1", "name2"}
 	cols := [][]gauge.TableCell{{cell1}, {cell2}}

--- a/gauge/arg_test.go
+++ b/gauge/arg_test.go
@@ -45,9 +45,11 @@ func (s *MySuite) TestLookupContainsArg(c *C) {
 func (s *MySuite) TestAddArgValue(c *C) {
 	lookup := new(ArgLookup)
 	lookup.AddArgName("param1")
-	lookup.AddArgValue("param1", &StepArg{Value: "value1", ArgType: Static})
+	err := lookup.AddArgValue("param1", &StepArg{Value: "value1", ArgType: Static})
+	c.Assert(err, IsNil)
 	lookup.AddArgName("param2")
-	lookup.AddArgValue("param2", &StepArg{Value: "value2", ArgType: Dynamic})
+	err = lookup.AddArgValue("param2", &StepArg{Value: "value2", ArgType: Dynamic})
+	c.Assert(err, IsNil)
 	stepArg, err := lookup.GetArg("param1")
 	c.Assert(err, IsNil)
 	c.Assert(stepArg.Value, Equals, "value1")
@@ -68,10 +70,13 @@ func (s *MySuite) TestErrorForInvalidArg(c *C) {
 func (s *MySuite) TestGetLookupCopy(c *C) {
 	originalLookup := new(ArgLookup)
 	originalLookup.AddArgName("param1")
-	originalLookup.AddArgValue("param1", &StepArg{Value: "oldValue", ArgType: Dynamic})
+	err := originalLookup.AddArgValue("param1", &StepArg{Value: "oldValue", ArgType: Dynamic})
+	c.Assert(err, IsNil)
 
 	copiedLookup, _ := originalLookup.GetCopy()
-	copiedLookup.AddArgValue("param1", &StepArg{Value: "new value", ArgType: Static})
+	err = copiedLookup.AddArgValue("param1", &StepArg{Value: "new value", ArgType: Static})
+	c.Assert(err, IsNil)
+
 	stepArg, err := copiedLookup.GetArg("param1")
 	c.Assert(err, IsNil)
 	c.Assert(stepArg.Value, Equals, "new value")

--- a/gauge/specCollection.go
+++ b/gauge/specCollection.go
@@ -28,7 +28,7 @@ type SpecCollection struct {
 }
 
 func NewSpecCollection(s []*Specification, groupDataTableSpecs bool) *SpecCollection {
-	if groupDataTableSpecs == false {
+	if !groupDataTableSpecs {
 		var specs [][]*Specification
 		for _, spec := range s {
 			specs = append(specs, []*Specification{spec})

--- a/gauge/step_test.go
+++ b/gauge/step_test.go
@@ -36,7 +36,9 @@ func (s *MySuite) TestPopulateFragmentsForSimpleStep(c *C) {
 func (s *MySuite) TestGetArgForStep(c *C) {
 	lookup := new(ArgLookup)
 	lookup.AddArgName("param1")
-	lookup.AddArgValue("param1", &StepArg{Value: "value1", ArgType: Static})
+	err := lookup.AddArgValue("param1", &StepArg{Value: "value1", ArgType: Static})
+	c.Assert(err, IsNil)
+
 	step := &Step{Lookup: *lookup}
 	stepArg, err := step.GetArg("param1")
 	c.Assert(err, IsNil)
@@ -46,11 +48,15 @@ func (s *MySuite) TestGetArgForStep(c *C) {
 func (s *MySuite) TestGetArgForConceptStep(c *C) {
 	lookup := new(ArgLookup)
 	lookup.AddArgName("param1")
-	lookup.AddArgValue("param1", &StepArg{Value: "value1", ArgType: Static})
+	err := lookup.AddArgValue("param1", &StepArg{Value: "value1", ArgType: Static})
+	c.Assert(err, IsNil)
+
 	concept := &Step{Lookup: *lookup, IsConcept: true}
 	stepLookup := new(ArgLookup)
 	stepLookup.AddArgName("param1")
-	stepLookup.AddArgValue("param1", &StepArg{Value: "param1", ArgType: Dynamic})
+	err = stepLookup.AddArgValue("param1", &StepArg{Value: "param1", ArgType: Dynamic})
+	c.Assert(err, IsNil)
+
 	step := &Step{Parent: concept, Lookup: *stepLookup}
 
 	stepArg, err := step.GetArg("param1")

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/dmotylev/goproperties v0.0.0-20140630191356-7cbffbaada47
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/getgauge/common v0.0.0-20180424115244-657067401e5f
+	github.com/go-check/check v0.0.0-20190902080502-41f04d3bba15 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.3.2-0.20190318194812-d3c38a4eb497
 	github.com/jpillora/go-ogle-analytics v0.0.0-20161213085824-14b04e0594ef

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/getgauge/common v0.0.0-20180424115244-657067401e5f h1:2oIXAhN/mLgicSV5U4Ik4n+rLKOVArHg/hYyj7bPnDI=
 github.com/getgauge/common v0.0.0-20180424115244-657067401e5f/go.mod h1:tHtGp+rvfECQYRDCNQX46uQTO6qHpdDrikX9ZkBjkSA=
+github.com/go-check/check v0.0.0-20190902080502-41f04d3bba15 h1:xJdCV5uP69sUzCIIzmhAw6EKKdVk3Tu48oLzM86+XPI=
+github.com/go-check/check v0.0.0-20190902080502-41f04d3bba15/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/protobuf v1.3.2-0.20190318194812-d3c38a4eb497 h1:5mkx1LI1iV+rjlOjWq4uRg00nMQztq85do3Pl6UfShA=
 github.com/golang/protobuf v1.3.2-0.20190318194812-d3c38a4eb497/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -141,9 +141,9 @@ func TestGetErrorText(t *testing.T) {
 		expectedText string
 	}{
 		{
-			gaugeVersion: &version.Version{0, 9, 8},
+			gaugeVersion: &version.Version{Major: 0, Minor: 9, Patch: 8},
 			commitHash:   "",
-			pluginInfos:  []pluginInfo.PluginInfo{{Name: "java", Version: &version.Version{0, 6, 6}}},
+			pluginInfos:  []pluginInfo.PluginInfo{{Name: "java", Version: &version.Version{Major: 0, Minor: 6, Patch: 6}}},
 			expectedText: fmt.Sprintf(`Error ----------------------------------
 
 An Error has Occurred: some error
@@ -158,11 +158,11 @@ Your Environment Information -----------
 	java (0.6.6)`, runtime.GOOS),
 		},
 		{
-			gaugeVersion: &version.Version{0, 9, 8},
+			gaugeVersion: &version.Version{Major: 0, Minor: 9, Patch: 8},
 			commitHash:   "",
 			pluginInfos: []pluginInfo.PluginInfo{
-				{Name: "java", Version: &version.Version{0, 6, 6}},
-				{Name: "html-report", Version: &version.Version{0, 4, 0}},
+				{Name: "java", Version: &version.Version{Major: 0, Minor: 6, Patch: 6}},
+				{Name: "html-report", Version: &version.Version{Major: 0, Minor: 4, Patch: 0}},
 			},
 			expectedText: fmt.Sprintf(`Error ----------------------------------
 
@@ -178,11 +178,11 @@ Your Environment Information -----------
 	java (0.6.6), html-report (0.4.0)`, runtime.GOOS),
 		},
 		{
-			gaugeVersion: &version.Version{0, 9, 8},
+			gaugeVersion: &version.Version{Major: 0, Minor: 9, Patch: 8},
 			commitHash:   "59effa",
 			pluginInfos: []pluginInfo.PluginInfo{
-				{Name: "java", Version: &version.Version{0, 6, 6}},
-				{Name: "html-report", Version: &version.Version{0, 4, 0}},
+				{Name: "java", Version: &version.Version{Major: 0, Minor: 6, Patch: 6}},
+				{Name: "html-report", Version: &version.Version{Major: 0, Minor: 4, Patch: 0}},
 			},
 			expectedText: fmt.Sprintf(`Error ----------------------------------
 

--- a/parser/conceptParser_test.go
+++ b/parser/conceptParser_test.go
@@ -21,10 +21,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"testing"
+
 	"github.com/getgauge/gauge/config"
 	"github.com/getgauge/gauge/gauge"
 	. "gopkg.in/check.v1"
-	"testing"
 )
 
 func assertStepEqual(c *C, expected, actual *gauge.Step) {
@@ -83,7 +84,8 @@ func (s *MySuite) TestDuplicateConceptsinMultipleFile(c *C) {
 	cpt1, _ := filepath.Abs(filepath.Join("testdata", "err", "cpt", "concept.cpt"))
 	cpt2, _ := filepath.Abs(filepath.Join("testdata", "err", "cpt", "duplicate.cpt"))
 
-	AddConcepts([]string{cpt1}, dictionary)
+	_, _, err := AddConcepts([]string{cpt1}, dictionary)
+	c.Assert(err, IsNil)
 	concepts, errs, err := AddConcepts([]string{cpt2}, dictionary)
 	c.Assert(err, IsNil)
 
@@ -120,7 +122,8 @@ func (s *MySuite) TestConceptDictionaryWithNestedConcepts(c *C) {
 	dictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "nested_concept.cpt"))
 
-	AddConcepts([]string{path}, dictionary)
+	_, _, err := AddConcepts([]string{path}, dictionary)
+	c.Assert(err, IsNil)
 	concept := dictionary.Search("test concept step 1")
 
 	c.Assert(len(concept.ConceptStep.ConceptSteps), Equals, 1)
@@ -135,7 +138,8 @@ func (s *MySuite) TestConceptDictionaryWithNestedConceptsWithDynamicParameters(c
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "dynamic_param_concept.cpt"))
 
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 	concept := conceptDictionary.Search("create user {} {} and {}")
 	c.Assert(len(concept.ConceptStep.ConceptSteps), Equals, 1)
 	actualNestedConcept := concept.ConceptStep.ConceptSteps[0]
@@ -155,7 +159,8 @@ func (s *MySuite) TestConceptDictionaryWithNestedConceptsWithStaticParameters(c 
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "static_param_concept.cpt"))
 
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 	concept := conceptDictionary.Search("create user {} {} and {}")
 	c.Assert(len(concept.ConceptStep.ConceptSteps), Equals, 2)
 	actualNestedConcept := concept.ConceptStep.ConceptSteps[0]
@@ -187,7 +192,8 @@ func (s *MySuite) TestConceptHavingItemsWithComments(c *C) {
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "dynamic_param_concept.cpt"))
 
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 	concept := conceptDictionary.Search("create user {} {} and {}")
 
 	c.Assert(len(concept.ConceptStep.Items), Equals, 3)
@@ -203,7 +209,8 @@ func (s *MySuite) TestConceptHavingItemsComments(c *C) {
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "tabular_concept.cpt"))
 
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 
 	concept := conceptDictionary.Search("my concept {}")
 	c.Assert(len(concept.ConceptStep.Items), Equals, 3)
@@ -216,7 +223,10 @@ func TestConceptHavingItemsWithTables(t *testing.T) {
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "tabular_concept.cpt"))
 
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	if err != nil {
+		t.Error(err)
+	}
 
 	concept := conceptDictionary.Search("my concept {}")
 	if len(concept.ConceptStep.Items) != 3 {
@@ -234,7 +244,10 @@ func TestConceptHavingConceptStepWithInlineTable(t *testing.T) {
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "tabular_concept2.cpt"))
 
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	if err != nil {
+		t.Error(err)
+	}
 
 	concept := conceptDictionary.Search("my concept")
 	if got := len(concept.ConceptStep.Items); got != 2 {
@@ -262,7 +275,8 @@ func (s *MySuite) TestMultiLevelConcept(c *C) {
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "nested_concept2.cpt"))
 
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 	actualTopLevelConcept := conceptDictionary.Search("top level concept")
 	c.Assert(len(actualTopLevelConcept.ConceptStep.ConceptSteps), Equals, 2)
 	actualNestedConcept := actualTopLevelConcept.ConceptStep.ConceptSteps[0]
@@ -468,7 +482,8 @@ func (s *MySuite) TestNestedConceptLooksUpArgsFromParent(c *C) {
 	dictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "param_nested_concept.cpt"))
 
-	AddConcepts([]string{path}, dictionary)
+	_, _, err := AddConcepts([]string{path}, dictionary)
+	c.Assert(err, IsNil)
 	tokens, _ := parser.GenerateTokens(specText, "")
 	spec, parseResult, _ := parser.CreateSpecification(tokens, dictionary, "")
 
@@ -495,7 +510,8 @@ func (s *MySuite) TestNestedConceptLooksUpDataTableArgs(c *C) {
 	dictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "param_nested_concept.cpt"))
 
-	AddConcepts([]string{path}, dictionary)
+	_, _, err := AddConcepts([]string{path}, dictionary)
+	c.Assert(err, IsNil)
 
 	tokens, _ := parser.GenerateTokens(specText, "")
 	spec, parseResult, _ := parser.CreateSpecification(tokens, dictionary, "")
@@ -535,7 +551,8 @@ func (s *MySuite) TestNestedConceptLooksUpWhenParameterPlaceholdersAreSame(c *C)
 	dictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "param_nested_concept2.cpt"))
 
-	AddConcepts([]string{path}, dictionary)
+	_, _, err := AddConcepts([]string{path}, dictionary)
+	c.Assert(err, IsNil)
 
 	tokens, _ := parser.GenerateTokens(specText, "")
 	spec, parseResult, _ := parser.CreateSpecification(tokens, dictionary, "")
@@ -591,7 +608,8 @@ func (s *MySuite) TestValidateConceptShouldRemoveCircularConceptsFromDictionary(
 	cd := gauge.NewConceptDictionary()
 	c1 := &gauge.Step{LineText: "concept", Value: "concept", IsConcept: true, ConceptSteps: []*gauge.Step{&gauge.Step{LineText: "concept2", Value: "concept2", IsConcept: true}}}
 	c2 := &gauge.Step{LineText: "concept2", Value: "concept2", IsConcept: true, ConceptSteps: []*gauge.Step{&gauge.Step{LineText: "concept", Value: "concept", IsConcept: true}}}
-	AddConcept([]*gauge.Step{c1, c2}, "filename.cpt", cd)
+	_, err := AddConcept([]*gauge.Step{c1, c2}, "filename.cpt", cd)
+	c.Assert(err, IsNil)
 
 	res := ValidateConcepts(cd)
 
@@ -618,14 +636,16 @@ func (s *MySuite) TestRemoveAllReferences(c *C) {
 func (s *MySuite) TestReplaceNestedConceptsWithCircularReference(c *C) {
 	lookup := gauge.ArgLookup{}
 	lookup.AddArgName("a")
-	lookup.AddArgValue("a", &gauge.StepArg{Name: "", Value: "a", ArgType: gauge.Static})
+	err := lookup.AddArgValue("a", &gauge.StepArg{Name: "", Value: "a", ArgType: gauge.Static})
+	c.Assert(err, IsNil)
 	lookup.ParamIndexMap = make(map[string]int)
 	lookup.ParamIndexMap["a"] = 0
 
 	cd := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "err", "cpt", "circular_concept.cpt"))
 
-	AddConcepts([]string{path}, cd)
+	_, _, err = AddConcepts([]string{path}, cd)
+	c.Assert(err, IsNil)
 	concept := cd.Search("concept1 {}")
 
 	c.Assert(concept.ConceptStep.ConceptSteps[0].Lookup, DeepEquals, lookup)
@@ -738,7 +758,8 @@ func (s *MySuite) TestConceptFileHavingItemsWithDuplicateTableHeaders(c *C) {
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "tabular_concept1.cpt"))
 
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 	concept := conceptDictionary.Search("my concept {}")
 	concept1 := conceptDictionary.Search("my {}")
 

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -37,7 +37,6 @@
 package parser
 
 import (
-	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -132,12 +131,6 @@ func ParseConcepts() (*gauge.ConceptDictionary, *ParseResult, error) {
 	HandleParseResult(conceptParseResult)
 	logger.Debugf(true, "%d concepts parsing completed.", len(conceptsDictionary.ConceptsMap))
 	return conceptsDictionary, conceptParseResult, nil
-}
-
-func recoverPanic() {
-	if r := recover(); r != nil {
-		logger.Fatalf(true, "%v\n%s", r, string(debug.Stack()))
-	}
 }
 
 func parseSpec(specFile string, conceptDictionary *gauge.ConceptDictionary) (*gauge.Specification, *ParseResult) {

--- a/parser/resolver_test.go
+++ b/parser/resolver_test.go
@@ -95,13 +95,15 @@ func (s *MySuite) TestPopulatingConceptLookup(c *C) {
 
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "dynamic_param_concept.cpt"))
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 	spec, _, _ := parser.Parse(specText, conceptDictionary, "")
 	concept := spec.Scenarios[0].Steps[0]
 
 	dataTableLookup := new(gauge.ArgLookup)
-	dataTableLookup.ReadDataTableRow(&spec.DataTable.Table, 0)
-	err := PopulateConceptDynamicParams(concept, dataTableLookup)
+	err = dataTableLookup.ReadDataTableRow(&spec.DataTable.Table, 0)
+	c.Assert(err, IsNil)
+	err = PopulateConceptDynamicParams(concept, dataTableLookup)
 	c.Assert(err, IsNil)
 	useridArg, _ := concept.GetArg("user-id")
 	c.Assert(useridArg.Value, Equals, "123")
@@ -124,13 +126,15 @@ func (s *MySuite) TestPopulatingNestedConceptLookup(c *C) {
 
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "dynamic_param_concept.cpt"))
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 	spec, _, _ := parser.Parse(specText, conceptDictionary, "")
 	concept1 := spec.Scenarios[0].Steps[0]
 
 	dataTableLookup := new(gauge.ArgLookup)
-	dataTableLookup.ReadDataTableRow(&spec.DataTable.Table, 0)
-	err := PopulateConceptDynamicParams(concept1, dataTableLookup)
+	err = dataTableLookup.ReadDataTableRow(&spec.DataTable.Table, 0)
+	c.Assert(err, IsNil)
+	err = PopulateConceptDynamicParams(concept1, dataTableLookup)
 	c.Assert(err, IsNil)
 
 	useridArg1, _ := concept1.GetArg("user-id")
@@ -170,14 +174,16 @@ func (s *MySuite) TestPopulatingNestedConceptsWithStaticParametersLookup(c *C) {
 
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "static_param_concept.cpt"))
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 
 	spec, _, _ := parser.Parse(specText, conceptDictionary, "")
 	concept1 := spec.Scenarios[0].Steps[0]
 
 	dataTableLookup := new(gauge.ArgLookup)
-	dataTableLookup.ReadDataTableRow(&spec.DataTable.Table, 0)
-	err := PopulateConceptDynamicParams(concept1, dataTableLookup)
+	err = dataTableLookup.ReadDataTableRow(&spec.DataTable.Table, 0)
+	c.Assert(err, IsNil)
+	err = PopulateConceptDynamicParams(concept1, dataTableLookup)
 	c.Assert(err, IsNil)
 	useridArg1, _ := concept1.GetArg("user-id")
 	c.Assert(useridArg1.Value, Equals, "456")
@@ -205,14 +211,16 @@ func (s *MySuite) TestPopulatingConceptsWithDynamicParametersInTable(c *C) {
 		String()
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "table_param_concept.cpt"))
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 
 	spec, _, _ := parser.Parse(specText, conceptDictionary, "")
 	concept1 := spec.Scenarios[0].Steps[0]
 
 	dataTableLookup := new(gauge.ArgLookup)
-	dataTableLookup.ReadDataTableRow(&spec.DataTable.Table, 0)
-	err := PopulateConceptDynamicParams(concept1, dataTableLookup)
+	err = dataTableLookup.ReadDataTableRow(&spec.DataTable.Table, 0)
+	c.Assert(err, IsNil)
+	err = PopulateConceptDynamicParams(concept1, dataTableLookup)
 	c.Assert(err, IsNil)
 	tableArg, err := concept1.Lookup.GetArg("addresses")
 	c.Assert(err, IsNil)
@@ -231,7 +239,8 @@ func (s *MySuite) TestEachConceptUsageIsUpdatedWithRespectiveParams(c *C) {
 
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "static_param_concept.cpt"))
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 	spec, _, _ := parser.Parse(specText, conceptDictionary, "")
 	concept1 := spec.Scenarios[0].Steps[0]
 

--- a/parser/specparser_test.go
+++ b/parser/specparser_test.go
@@ -77,9 +77,10 @@ func (s *MySuite) TestParsingConceptInSpec(c *C) {
 		step("another step").String()
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "concept.cpt"))
-	AddConcepts([]string{path}, conceptDictionary)
-	tokens, err := parser.GenerateTokens(specText, "")
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
 	c.Assert(err, IsNil)
+	tokens, errs := parser.GenerateTokens(specText, "")
+	c.Assert(errs, IsNil)
 	spec, parseResult, e := parser.CreateSpecification(tokens, conceptDictionary, "")
 	c.Assert(e, IsNil)
 	c.Assert(parseResult.Ok, Equals, true)
@@ -774,7 +775,8 @@ func (s *MySuite) TestCreateStepFromSimpleConcept(c *C) {
 
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "concept.cpt"))
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 	spec, result, err := new(SpecParser).CreateSpecification(tokens, conceptDictionary, "")
 	c.Assert(err, IsNil)
 	c.Assert(result.Ok, Equals, true)
@@ -795,7 +797,8 @@ func (s *MySuite) TestCreateStepFromConceptWithParameters(c *C) {
 
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "dynamic_param_concept.cpt"))
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 
 	spec, result, err := new(SpecParser).CreateSpecification(tokens, conceptDictionary, "")
 	c.Assert(err, IsNil)
@@ -838,7 +841,8 @@ func (s *MySuite) TestCreateStepFromConceptWithDynamicParameters(c *C) {
 
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "dynamic_param_concept.cpt"))
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 	spec, result, err := new(SpecParser).CreateSpecification(tokens, conceptDictionary, "")
 	c.Assert(err, IsNil)
 	c.Assert(result.Ok, Equals, true)
@@ -882,7 +886,8 @@ func (s *MySuite) TestCreateStepFromConceptWithInlineTable(c *C) {
 
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "dynamic_param_concept.cpt"))
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 	spec, result, err := new(SpecParser).CreateSpecification(tokens, conceptDictionary, "")
 	c.Assert(err, IsNil)
 	c.Assert(result.Ok, Equals, true)
@@ -910,7 +915,8 @@ func (s *MySuite) TestCreateStepFromConceptWithInlineTableHavingDynamicParam(c *
 
 	conceptDictionary := gauge.NewConceptDictionary()
 	path, _ := filepath.Abs(filepath.Join("testdata", "dynamic_param_concept.cpt"))
-	AddConcepts([]string{path}, conceptDictionary)
+	_, _, err := AddConcepts([]string{path}, conceptDictionary)
+	c.Assert(err, IsNil)
 	spec, result, err := new(SpecParser).CreateSpecification(tokens, conceptDictionary, "")
 	c.Assert(err, IsNil)
 	c.Assert(result.Ok, Equals, true)

--- a/parser/stepParser.go
+++ b/parser/stepParser.go
@@ -45,8 +45,6 @@ const (
 	specialParamIdentifier = ':'
 )
 
-var allEscapeChars = map[string]string{`\t`: "\t", `\n`: "\n", `\r`: "\r"}
-
 type acceptFn func(rune, int) (int, bool)
 
 // ExtractStepArgsFromToken extracts step args(Static and Dynamic) from the given step token.
@@ -259,9 +257,7 @@ func treatArgAsDynamic(argValue string, token *Token, lookup *gauge.ArgLookup, f
 			parseRes.ParseErrors = result.ParseErrors
 		}
 		if result.Warnings != nil {
-			for _, warn := range result.Warnings {
-				parseRes.Warnings = append(parseRes.Warnings, warn)
-			}
+			parseRes.Warnings = append(parseRes.Warnings, result.Warnings...)
 		}
 	}
 	return stepArg, parseRes

--- a/plugin/install/check_test.go
+++ b/plugin/install/check_test.go
@@ -28,7 +28,7 @@ func (s *MySuite) TestCheckGaugeUpdateWhenThereIsAnUpdate(c *C) {
 	getLatestGaugeVersion = func(url string) (string, error) {
 		return "0.1.0", nil
 	}
-	version.CurrentGaugeVersion = &version.Version{0, 0, 1}
+	version.CurrentGaugeVersion = &version.Version{Major: 0, Minor: 0, Patch: 1}
 	updateInfo := checkGaugeUpdate()[0]
 	c.Assert(updateInfo.CompatibleVersion, Equals, "0.1.0")
 	c.Assert(updateInfo.Name, Equals, "Gauge")
@@ -38,13 +38,13 @@ func (s *MySuite) TestCheckGaugeUpdateWhenThereIsNoUpdate(c *C) {
 	getLatestGaugeVersion = func(url string) (string, error) {
 		return "0.1.0", nil
 	}
-	version.CurrentGaugeVersion = &version.Version{0, 2, 0}
+	version.CurrentGaugeVersion = &version.Version{Major: 0, Minor: 2, Patch: 0}
 	updateInfos := checkGaugeUpdate()
 	c.Assert(len(updateInfos), Equals, 0)
 }
 
 func (s *MySuite) TestCreatePluginUpdateDetailWhenThereIsAnUpdate(c *C) {
-	version.CurrentGaugeVersion = &version.Version{0, 1, 1}
+	version.CurrentGaugeVersion = &version.Version{Major: 0, Minor: 1, Patch: 1}
 	ruby := "ruby"
 	i := installDescription{Name: ruby, Versions: []versionInstallDescription{versionInstallDescription{Version: "0.1.1", GaugeVersionSupport: version.VersionSupport{Minimum: "0.1.0", Maximum: "0.1.2"}}}}
 	updateDetails := createPluginUpdateDetail("0.1.0", i)
@@ -55,7 +55,7 @@ func (s *MySuite) TestCreatePluginUpdateDetailWhenThereIsAnUpdate(c *C) {
 }
 
 func (s *MySuite) TestCreatePluginUpdateDetailWhenThereIsNoUpdate(c *C) {
-	version.CurrentGaugeVersion = &version.Version{0, 1, 1}
+	version.CurrentGaugeVersion = &version.Version{Major: 0, Minor: 1, Patch: 1}
 	ruby := "ruby"
 	i := installDescription{Name: ruby, Versions: []versionInstallDescription{versionInstallDescription{Version: "0.1.0", GaugeVersionSupport: version.VersionSupport{Minimum: "0.1.0", Maximum: "0.1.2"}}}}
 	updateDetails := createPluginUpdateDetail("0.1.0", i)
@@ -72,7 +72,7 @@ func (s *MySuite) TestGetGaugeVersionFromURL(c *C) {
 }
 
 func (s *MySuite) TestCreatePluginUpdateDetailForNightly(c *C) {
-	version.CurrentGaugeVersion = &version.Version{0, 1, 1}
+	version.CurrentGaugeVersion = &version.Version{Major: 0, Minor: 1, Patch: 1}
 	ruby := "ruby"
 	i := installDescription{Name: ruby, Versions: []versionInstallDescription{versionInstallDescription{Version: "0.1.1.nightly.2050-02-01", GaugeVersionSupport: version.VersionSupport{Minimum: "0.1.0", Maximum: "0.1.2"}}}}
 	updateDetails := createPluginUpdateDetail("0.1.0", i)

--- a/plugin/install/install_test.go
+++ b/plugin/install/install_test.go
@@ -60,11 +60,11 @@ func (s *MySuite) TestSortingVersionInstallDescriptionsInDecreasingVersionOrder(
 func (s *MySuite) TestFindingLatestCompatibleVersionSuccess(c *C) {
 	installDescription := createInstallDescriptionWithVersions("5.8.8", "1.7.8", "4.8.9", "0.7.6")
 	addVersionSupportToInstallDescription(installDescription,
-		&version.VersionSupport{"0.0.2", "0.8.7"},
-		&version.VersionSupport{"1.2.4", "1.2.6"},
-		&version.VersionSupport{"0.9.8", "1.2.1"},
+		&version.VersionSupport{Minimum: "0.0.2", Maximum: "0.8.7"},
+		&version.VersionSupport{Minimum: "1.2.4", Maximum: "1.2.6"},
+		&version.VersionSupport{Minimum: "0.9.8", Maximum: "1.2.1"},
 		&version.VersionSupport{Minimum: "0.7.7"})
-	versionInstallDesc, err := installDescription.getLatestCompatibleVersionTo(&version.Version{1, 0, 0})
+	versionInstallDesc, err := installDescription.getLatestCompatibleVersionTo(&version.Version{Major: 1, Minor: 0, Patch: 0})
 	c.Assert(err, Equals, nil)
 	c.Assert(versionInstallDesc.Version, Equals, "4.8.9")
 }
@@ -72,11 +72,11 @@ func (s *MySuite) TestFindingLatestCompatibleVersionSuccess(c *C) {
 func (s *MySuite) TestFindingLatestCompatibleVersionFailing(c *C) {
 	installDescription := createInstallDescriptionWithVersions("2.8.8", "0.7.8", "4.8.9", "1.7.6")
 	addVersionSupportToInstallDescription(installDescription,
-		&version.VersionSupport{"0.0.2", "0.8.7"},
-		&version.VersionSupport{"1.2.4", "1.2.6"},
-		&version.VersionSupport{"0.9.8", "1.0.0"},
+		&version.VersionSupport{Minimum: "0.0.2", Maximum: "0.8.7"},
+		&version.VersionSupport{Minimum: "1.2.4", Maximum: "1.2.6"},
+		&version.VersionSupport{Minimum: "0.9.8", Maximum: "1.0.0"},
 		&version.VersionSupport{Minimum: "1.7.7"})
-	_, err := installDescription.getLatestCompatibleVersionTo(&version.Version{1, 1, 0})
+	_, err := installDescription.getLatestCompatibleVersionTo(&version.Version{Major: 1, Minor: 1, Patch: 0})
 	c.Assert(err, NotNil)
 }
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -47,7 +47,6 @@ const (
 	executionScope          pluginScope = "execution"
 	docScope                pluginScope = "documentation"
 	pluginConnectionPortEnv             = "plugin_connection_port"
-	debugEnv                            = "debugging"
 )
 
 type plugin struct {
@@ -266,7 +265,10 @@ func startPluginsForExecution(manifest *manifest.Manifest) (Handler, []string) {
 			pluginConnection, err := gaugeConnectionHandler.AcceptConnection(config.PluginConnectionTimeout(), make(chan error))
 			if err != nil {
 				warnings = append(warnings, fmt.Sprintf("Error starting plugin %s %s. Failed to connect to plugin. %s", pd.Name, pd.Version, err.Error()))
-				plugin.pluginCmd.Process.Kill()
+				err := plugin.pluginCmd.Process.Kill()
+				if err != nil {
+					logger.Errorf(false, "unable to kill plugin %s: %s", plugin.descriptor.Name, err.Error())
+				}
 				continue
 			}
 			logger.Debugf(true, "Established connection to %s plugin", pd.Name)

--- a/refactor/refactor.go
+++ b/refactor/refactor.go
@@ -267,7 +267,7 @@ func (agent *rephraseRefactorer) refactorStepImplementations(shouldSaveChanges b
 }
 
 func (agent *rephraseRefactorer) rephraseInSpecsAndConcepts(specs *[]*gauge.Specification, conceptDictionary *gauge.ConceptDictionary) (map[*gauge.Specification][]*gauge.StepDiff, map[string][]*gauge.StepDiff) {
-	specsRefactored := make(map[*gauge.Specification][]*gauge.StepDiff, 0)
+	specsRefactored := make(map[*gauge.Specification][]*gauge.StepDiff)
 	conceptsRefactored := make(map[string][]*gauge.StepDiff)
 	orderMap := agent.createOrderOfArgs()
 	for _, spec := range *specs {

--- a/reporter/coloredConsole_test.go
+++ b/reporter/coloredConsole_test.go
@@ -30,7 +30,8 @@ func (s *MySuite) TestScenarioEndInNonVerbose_ColoredConsole(c *C) {
 	cc.ScenarioStart(&gauge.Scenario{Heading: &gauge.Heading{Value: "failing step"}}, gauge_messages.ExecutionInfo{}, scnRes)
 	dw.output = ""
 
-	cc.Write([]byte("fail reason: blah"))
+	_, err := cc.Write([]byte("fail reason: blah"))
+	c.Assert(err, IsNil)
 	cc.ScenarioEnd(nil, scnRes, gauge_messages.ExecutionInfo{})
 
 	c.Assert(dw.output, Equals, "fail reason: blah\n")

--- a/reporter/jsonConsole.go
+++ b/reporter/jsonConsole.go
@@ -43,7 +43,6 @@ const (
 	scenarioEnd   eventType = "scenarioEnd"
 	specEnd       eventType = "specEnd"
 	suiteEnd      eventType = "suiteEnd"
-	errorResult   eventType = "error"
 	pass          status    = "pass"
 	fail          status    = "fail"
 	skip          status    = "skip"

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -128,7 +128,7 @@ func initParallelReporters() {
 
 // ListenExecutionEvents listens to all execution events for reporting on console
 func ListenExecutionEvents(wg *sync.WaitGroup) {
-	ch := make(chan event.ExecutionEvent, 0)
+	ch := make(chan event.ExecutionEvent)
 	initParallelReporters()
 	event.Register(ch, event.SuiteStart, event.SpecStart, event.SpecEnd, event.ScenarioStart, event.ScenarioEnd, event.StepStart, event.StepEnd, event.ConceptStart, event.ConceptEnd, event.SuiteEnd)
 	var r Reporter

--- a/reporter/simpleConsole_test.go
+++ b/reporter/simpleConsole_test.go
@@ -227,7 +227,8 @@ func (s *MySuite) TestSpecReporting_SimpleConsole(c *C) {
 	sc.SpecStart(&gauge.Specification{Heading: &gauge.Heading{Value: "Specification heading"}}, &result.SpecResult{Skipped: false})
 	sc.ScenarioStart(&gauge.Scenario{Heading: &gauge.Heading{Value: "My First scenario"}}, gauge_messages.ExecutionInfo{}, scnRes)
 	sc.StepStart("* do foo bar")
-	sc.Write([]byte("doing foo bar"))
+	_, err := sc.Write([]byte("doing foo bar"))
+	c.Assert(err, IsNil)
 	res := result.NewScenarioResult(&gauge_messages.ProtoScenario{ExecutionStatus: gauge_messages.ExecutionStatus_PASSED, Failed: false})
 	specInfo := gauge_messages.ExecutionInfo{CurrentSpec: &gauge_messages.SpecInfo{Name: "hello.spec"}}
 	stepExeRes := &gauge_messages.ProtoStepExecutionResult{ExecutionResult: &gauge_messages.ProtoExecutionResult{Failed: false}}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -222,9 +222,12 @@ func (r *LanguageRunner) EnsureConnected() bool {
 		return false
 	}
 	c := r.connection
-	c.SetReadDeadline(time.Now())
+	err := c.SetReadDeadline(time.Now())
+	if err != nil {
+		logger.Fatalf(true, "Unable to SetReadDeadLine on runner: %s", err.Error())
+	}
 	var one []byte
-	_, err := c.Read(one)
+	_, err = c.Read(one)
 	if err == io.EOF {
 		r.lostContact = true
 		logger.Fatalf(true, "Connection to runner with Pid %d lost. The runner probably quit unexpectedly. Inspect logs for potential reasons. Error : %s", r.Cmd.Process.Pid, err.Error())
@@ -235,7 +238,11 @@ func (r *LanguageRunner) EnsureConnected() bool {
 		logger.Fatalf(true, "Connection to runner with Pid %d lost. The runner probably quit unexpectedly. Inspect logs for potential reasons. Error : %s", r.Cmd.Process.Pid, err.Error())
 	}
 	var zero time.Time
-	c.SetReadDeadline(zero)
+	err = c.SetReadDeadline(zero)
+	if err != nil {
+		logger.Fatalf(true, "Unable to SetReadDeadLine on runner: %s", err.Error())
+	}
+
 	return true
 }
 

--- a/track/track.go
+++ b/track/track.go
@@ -45,7 +45,6 @@ const (
 	gaTestTrackingID = "UA-100778536-1"
 	appName          = "Gauge Core"
 	consoleMedium    = "console"
-	apiMedium        = "api"
 	ciMedium         = "CI"
 	timeout          = 1
 	// GaugeTelemetryMessageHeading is the header printed for telemetry warning

--- a/util/fileUtils_test.go
+++ b/util/fileUtils_test.go
@@ -101,14 +101,18 @@ func (s *MySuite) TestFindAllConceptFilesShouldFilterDirectoriesThatAreSkipped(c
 	reports, _ := createDirIn(dir, "reports")
 	env, _ := createDirIn(dir, "env")
 
-	createFileIn(git, "concept1.cpt", data)
-	createFileIn(bin, "concept2.cpt", data)
-	createFileIn(reports, "concept3.cpt", data)
-	createFileIn(env, "concept4.cpt", data)
+	_, err := createFileIn(git, "concept1.cpt", data)
+	c.Assert(err, IsNil)
+	_, err = createFileIn(bin, "concept2.cpt", data)
+	c.Assert(err, IsNil)
+	_, err = createFileIn(reports, "concept3.cpt", data)
+	c.Assert(err, IsNil)
+	_, err = createFileIn(env, "concept4.cpt", data)
+	c.Assert(err, IsNil)
 
 	c.Assert(len(FindConceptFilesIn(dir)), Equals, 0)
 
-	_, err := createFileIn(dir, "concept2.cpt", data)
+	_, err = createFileIn(dir, "concept2.cpt", data)
 	c.Assert(err, Equals, nil)
 	c.Assert(len(FindConceptFilesIn(dir)), Equals, 1)
 }
@@ -151,10 +155,14 @@ func (s *MySuite) TestFindAllNestedDirs(c *C) {
 	nested2 := filepath.Join(dir, "nested2")
 	nested3 := filepath.Join(dir, "nested2", "deep")
 	nested4 := filepath.Join(dir, "nested2", "deep", "deeper")
-	os.Mkdir(nested1, 0755)
-	os.Mkdir(nested2, 0755)
-	os.Mkdir(nested3, 0755)
-	os.Mkdir(nested4, 0755)
+	err := os.Mkdir(nested1, 0755)
+	c.Assert(err, IsNil)
+	err = os.Mkdir(nested2, 0755)
+	c.Assert(err, IsNil)
+	err = os.Mkdir(nested3, 0755)
+	c.Assert(err, IsNil)
+	err = os.Mkdir(nested4, 0755)
+	c.Assert(err, IsNil)
 
 	nestedDirs := FindAllNestedDirs(dir)
 	c.Assert(len(nestedDirs), Equals, 4)
@@ -197,8 +205,11 @@ func (s *MySuite) TestGetPathToFile(c *C) {
 }
 
 func createFileIn(dir string, fileName string, data []byte) (string, error) {
-	os.MkdirAll(dir, 0755)
-	err := ioutil.WriteFile(filepath.Join(dir, fileName), data, 0644)
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		return "", err
+	}
+	err = ioutil.WriteFile(filepath.Join(dir, fileName), data, 0644)
 	return filepath.Join(dir, fileName), err
 }
 

--- a/util/httpUtils_test.go
+++ b/util/httpUtils_test.go
@@ -84,7 +84,8 @@ func (s *MySuite) TestDownloadFailureIfTargetDirDoesntExist(c *C) {
 }
 
 func (s *MySuite) TestDownloadSuccess(c *C) {
-	os.Mkdir("temp", 0755)
+	err := os.Mkdir("temp", 0755)
+	c.Assert(err, IsNil)
 	defer os.RemoveAll("temp")
 
 	handler := func(w http.ResponseWriter, r *http.Request) {

--- a/validation/validate.go
+++ b/validation/validate.go
@@ -126,13 +126,20 @@ func Validate(args []string) {
 	}
 	if res.SpecCollection.Size() < 1 {
 		logger.Infof(true, "No specifications found in %s.", strings.Join(args, ", "))
-		res.Runner.Kill()
+		err := res.Runner.Kill()
+		if err != nil {
+			logger.Errorf(false, "unable to kill runner: %s", err.Error())
+		}
 		if res.ParseOk {
 			os.Exit(0)
 		}
 		os.Exit(1)
 	}
-	res.Runner.Kill()
+	err := res.Runner.Kill()
+	if err != nil {
+		logger.Errorf(false, "unable to kill runner: %s", err.Error())
+	}
+
 	if res.ErrMap.HasErrors() {
 		os.Exit(1)
 	}
@@ -181,7 +188,10 @@ func ValidateSpecs(args []string, debug bool) *ValidationResult {
 	printValidationFailures(vErrs)
 	showSuggestion(vErrs)
 	if !res.Ok {
-		r.Kill()
+		err := r.Kill()
+		if err != nil {
+			logger.Errorf(true, "unable to kill runner: %s", err.Error())
+		}
 		return NewValidationResult(nil, nil, nil, false, errors.New("Parsing failed"))
 	}
 	if specsFailed {


### PR DESCRIPTION
fixed issues reported by `govet`, `errcheck`, `gosimple` etc. run `golangci-lint run`.

details: https://github.com/golangci/golangci-lint