### PR TITLE
Fix suggestion to use nonexistent "list-templates" subcommand

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -36,7 +36,7 @@ var (
 				return
 			}
 			if len(args) < 1 {
-				exit(fmt.Errorf("Missing argument <template name>. To see all the templates, run 'gauge list-templates'"), cmd.UsageString())
+				exit(fmt.Errorf("Missing argument <template name>. To see all the templates, run 'gauge init -t'"), cmd.UsageString())
 			}
 			projectInit.InitializeProject(args[0], machineReadable)
 		},


### PR DESCRIPTION
The "list-templates" subcommand has been removed via https://github.com/getgauge/gauge/issues/693
in favor of a "-t/--templates" flag to the "init" subcommand.

Old usage: `gauge list-templates`
New usage: `gauge init --templates`

Closes #1543 