### PR TITLE
Fix release script error handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
               exit 1
           fi
           echo -e "Gauge v$version\n\n" > desc.txt
-          release_description=$(ruby -e "$(curl -sSfL https://github.com/getgauge/gauge/raw/master/build/create_release_text.rb)" gauge getgauge)
+          release_description=$(ruby -e "$(curl -sSfL https://github.com/getgauge/gauge/raw/master/build/create_release_text.rb)" getgauge gauge)
           echo "$release_description" >> desc.txt
           echo "Creating new draft for release v$version"
 

--- a/build/create_release_text.rb
+++ b/build/create_release_text.rb
@@ -71,5 +71,5 @@ case response
 
       https://github.com/#{repo}
 
-    Please check the if this is valid repo"
+    Please check if this is a valid repo."
 end


### PR DESCRIPTION
For example.

```
➜ ruby build/create_release_text.rb getgauge invalid
Traceback (most recent call last):
build/create_release_text.rb:69:in `<main>':  (RuntimeError)
    Could not fetch release information for github repo: 

      https://github.com/getgauge/invalid

    Please check the if this is valid repo
➜ ✗ 
```

Also fix the workflow script to pass the right order of parameter