### PR TITLE
allow spec file extensions to be configured, fixes #1599

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -54,7 +54,8 @@ const (
 	allowFilteredParallelExecution = "allow_filtered_parallel_execution"
 	enableMultithreading           = "enable_multithreading"
 	// GaugeScreenshotsDir holds the location of screenshots dir
-	GaugeScreenshotsDir = "gauge_screenshots_dir"
+	GaugeScreenshotsDir     = "gauge_screenshots_dir"
+	gaugeSpecFileExtensions = "gauge_spec_file_extensions"
 )
 
 var envVars map[string]string
@@ -123,6 +124,7 @@ func loadDefaultEnvVars() {
 	addEnvVar(allowFilteredParallelExecution, "false")
 	defaultScreenshotDir := filepath.Join(config.ProjectRoot, common.DotGauge, "screenshots")
 	addEnvVar(GaugeScreenshotsDir, defaultScreenshotDir)
+	addEnvVar(gaugeSpecFileExtensions, ".spec, .md")
 	err := os.MkdirAll(defaultScreenshotDir, 0750)
 	if err != nil {
 		logger.Warningf(true, "Could not create screenshot dir at %s", err.Error())
@@ -271,4 +273,20 @@ var SaveExecutionResult = func() bool {
 // for each parallel stream
 var EnableMultiThreadedExecution = func() bool {
 	return convertToBool(enableMultithreading, false)
+}
+
+var GaugeSpecFileExtensions = func() []string {
+	e := os.Getenv(gaugeSpecFileExtensions)
+	if e == "" {
+		e = ".spec, .md" //this was earlier hardcoded, this is a failsafe if env isn't set
+	}
+	exts := strings.Split(strings.TrimSpace(e), ",")
+	var allowedExts = []string{}
+	for _, ext := range exts {
+		e := strings.TrimSpace(ext)
+		if e != "" {
+			allowedExts = append(allowedExts, e)
+		}
+	}
+	return allowedExts
 }

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -49,6 +49,7 @@ func (s *MySuite) TestLoadDefaultEnv(c *C) {
 	c.Assert(os.Getenv("csv_delimiter"), Equals, ",")
 	defaultScreenshotDir := filepath.Join(config.ProjectRoot, common.DotGauge, "screenshots")
 	c.Assert(os.Getenv("gauge_screenshots_dir"), Equals, defaultScreenshotDir)
+	c.Assert(os.Getenv("gauge_spec_file_extensions"), Equals, ".spec, .md")
 }
 
 // If default env dir is present, the values present in there should overwrite
@@ -235,4 +236,57 @@ func (s *MySuite) TestCurrentEnvironmentIsPopulated(c *C) {
 
 	c.Assert(e, Equals, nil)
 	c.Assert(CurrentEnvironments(), Equals, "foo")
+}
+
+func (s *MySuite) TestGetDefaultSpecFileExtensions(c *C) {
+	os.Clearenv()
+	var contains = func(c []string, what string) bool {
+		for _, x := range c {
+			if x == what {
+				return true
+			}
+		}
+		return false
+	}
+
+	exts := GaugeSpecFileExtensions()
+	for _, expected := range []string{".spec", ".md"} {
+		c.Assert(contains(exts, expected), Equals, true)
+	}
+}
+
+func (s *MySuite) TestGetSpecFileExtensionsSetViaEnv(c *C) {
+	os.Clearenv()
+	os.Setenv(gaugeSpecFileExtensions, ".foo, .bar")
+	var contains = func(c []string, what string) bool {
+		for _, x := range c {
+			if x == what {
+				return true
+			}
+		}
+		return false
+	}
+
+	exts := GaugeSpecFileExtensions()
+	for _, expected := range []string{".foo", ".bar"} {
+		c.Assert(contains(exts, expected), Equals, true)
+	}
+}
+
+func (s *MySuite) TestShouldNotGetDefaultExtensionsWhenEnvIsSet(c *C) {
+	os.Clearenv()
+	os.Setenv(gaugeSpecFileExtensions, ".foo, .bar")
+	var contains = func(c []string, what string) bool {
+		for _, x := range c {
+			if x == what {
+				return true
+			}
+		}
+		return false
+	}
+
+	exts := GaugeSpecFileExtensions()
+	for _, expected := range []string{".spec", ".md"} {
+		c.Assert(contains(exts, expected), Equals, false)
+	}
 }

--- a/util/fileUtils.go
+++ b/util/fileUtils.go
@@ -32,17 +32,8 @@ import (
 const (
 	gaugeExcludeDirectories = "gauge_exclude_dirs"
 	cptFileExtension        = ".cpt"
-	specFileExtension       = ".spec"
-	mdFileExtension         = ".md"
 )
 
-func init() {
-	AcceptedExtensions[specFileExtension] = true
-	AcceptedExtensions[mdFileExtension] = true
-}
-
-// AcceptedExtensions has all the file extensions that are supported by Gauge for its specs
-var AcceptedExtensions = make(map[string]bool)
 var ignoredDirectories = make(map[string]bool)
 
 func add(value string) {
@@ -97,7 +88,12 @@ func FindSpecFilesIn(dir string) []string {
 
 // IsValidSpecExtension Checks if the path has a spec file extension
 func IsValidSpecExtension(path string) bool {
-	return AcceptedExtensions[strings.ToLower(filepath.Ext(path))]
+	for _, ext := range env.GaugeSpecFileExtensions() {
+		if ext == strings.ToLower(filepath.Ext(path)) {
+			return true
+		}
+	}
+	return false
 }
 
 // FindConceptFilesIn Finds the concept files in specified directory
@@ -134,13 +130,7 @@ func IsGaugeFile(path string) bool {
 
 // IsGaugeFile Returns true if spec file or concept file
 func GaugeFileExtensions() []string {
-	extensions := []string{cptFileExtension}
-	for ext, val := range AcceptedExtensions {
-		if val {
-			extensions = append(extensions, ext)
-		}
-	}
-	return extensions
+	return append(env.GaugeSpecFileExtensions(), cptFileExtension)
 }
 
 // FindAllNestedDirs returns list of all nested directories in given path

--- a/util/fileUtils_test.go
+++ b/util/fileUtils_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/getgauge/gauge/config"
+	"github.com/getgauge/gauge/env"
 	. "gopkg.in/check.v1"
 )
 
@@ -77,7 +78,7 @@ func (s *MySuite) TestFindAllConceptFiles(c *C) {
 	c.Assert(len(FindConceptFilesIn(dir)), Equals, 2)
 }
 
-func (s *MySuite) TestIsValidSpecExension(c *C) {
+func (s *MySuite) TestIsValidSpecExensionDefault(c *C) {
 	c.Assert(IsValidSpecExtension("/home/user/foo/myspec.spec"), Equals, true)
 	c.Assert(IsValidSpecExtension("/home/user/foo/myspec.sPeC"), Equals, true)
 	c.Assert(IsValidSpecExtension("/home/user/foo/myspec.SPEC"), Equals, true)
@@ -86,7 +87,30 @@ func (s *MySuite) TestIsValidSpecExension(c *C) {
 	c.Assert(IsValidSpecExtension("/home/user/foo/myconcept.cpt"), Equals, false)
 }
 
-func (s *MySuite) TestIsValidConcpetExension(c *C) {
+func TestIsValidSpecExensionWhenSet(t *testing.T) {
+	var tests = map[string]bool{
+		"/home/user/foo/myspec.spec":   true,
+		"/home/user/foo/myspec.sPeC":   true,
+		"/home/user/foo/myspec.SPEC":   true,
+		"/home/user/foo/myspec.md":     false,
+		"/home/user/foo/myspec.MD":     false,
+		"/home/user/foo/myspec.foo":    true,
+		"/home/user/foo/myspec.Foo":    true,
+		"/home/user/foo/myconcept.cpt": false,
+	}
+	for k, v := range tests {
+		t.Run(filepath.Ext(k), func(t *testing.T) {
+			old := env.GaugeSpecFileExtensions
+			env.GaugeSpecFileExtensions = func() []string { return []string{".spec", ".foo"} }
+			if IsValidSpecExtension(k) != v {
+				t.Errorf("Expected IsValidSpecExtension(%s) to be %t", k, v)
+			}
+			env.GaugeSpecFileExtensions = old
+		})
+	}
+}
+
+func (s *MySuite) TestIsValidConceptExension(c *C) {
 	c.Assert(IsValidConceptExtension("/home/user/foo/myconcept.cpt"), Equals, true)
 	c.Assert(IsValidConceptExtension("/home/user/foo/myconcept.CPT"), Equals, true)
 	c.Assert(IsValidConceptExtension("/home/user/foo/myconcept.cPt"), Equals, true)


### PR DESCRIPTION
set `gauge_spec_file_extensions=<comma separated val>` to define valid gauge spec file extensions.

If the above is not set, gauge shall default to `.spec` and `.md` as valid extensions (keeping current behaviour)