### PR TITLE
Exit with proper status code when specs dir is empty or doesn't exists.

### DIFF
--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -225,12 +225,6 @@ func (s *MySuite) TestGetAllSpecsShouldDeDuplicateIndexedSpecs(c *C) {
 	}
 }
 
-func (s *MySuite) TestGetAllSpecsForIndexedNonExistingSpec(c *C) {
-	_, indexedSpecs := getAllSpecFiles([]string{"example.spec" + ":1"})
-
-	c.Assert(len(indexedSpecs), Equals, 0)
-}
-
 func (s *MySuite) TestToCheckIfItsIndexedSpec(c *C) {
 	c.Assert(isIndexedSpec("specs/hello_world:as"), Equals, false)
 	c.Assert(isIndexedSpec("specs/hello_world.spec:0"), Equals, true)

--- a/util/fileUtils.go
+++ b/util/fileUtils.go
@@ -18,6 +18,7 @@
 package util
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -80,7 +81,7 @@ func findFilesIn(dirRoot string, isValidFile func(path string) bool, shouldSkip 
 }
 
 // FindSpecFilesIn Finds spec files in the given directory
-func FindSpecFilesIn(dir string) []string {
+var FindSpecFilesIn = func (dir string) []string {
 	return findFilesIn(dir, IsValidSpecExtension, func(path string, f os.FileInfo) bool {
 		return false
 	})
@@ -159,21 +160,23 @@ func IsDir(path string) bool {
 
 // GetSpecFiles returns the list of spec files present at the given path.
 // If the path itself represents a spec file, it returns the same.
+var exitWithMessage = func(message string) {
+	logger.Errorf(true, message)
+	os.Exit(1)
+}
 var GetSpecFiles = func(paths []string) []string {
 	var specFiles []string
 	for _, path := range paths {
 		if !common.FileExists(path) {
-			logger.Errorf(true, "Specs directory %s does not exists", path)
-			os.Exit(1)
+			exitWithMessage(fmt.Sprintf("Specs directory %s does not exists.", path))
 		}
 		if common.DirExists(path) {
 			specFilesInpath := FindSpecFilesIn(path)
 			if len(specFilesInpath) < 1 {
-				logger.Errorf(true, "No specifications found in %s.", path)
-				os.Exit(1)
+				exitWithMessage(fmt.Sprintf("No specifications found in %s.", path))
 			}
 			specFiles = append(specFiles, specFilesInpath...)
-		} else if common.FileExists(path) && IsValidSpecExtension(path) {
+		} else if IsValidSpecExtension(path) {
 			f, _ := filepath.Abs(path)
 			specFiles = append(specFiles, f)
 		}

--- a/util/fileUtils.go
+++ b/util/fileUtils.go
@@ -162,6 +162,10 @@ func IsDir(path string) bool {
 var GetSpecFiles = func(paths []string) []string {
 	var specFiles []string
 	for _, path := range paths {
+		if !common.FileExists(path) {
+			logger.Errorf(true, "Specs directory %s does not exists", path)
+			os.Exit(1)
+		}
 		if common.DirExists(path) {
 			specFiles = append(specFiles, FindSpecFilesIn(path)...)
 		} else if common.FileExists(path) && IsValidSpecExtension(path) {

--- a/util/fileUtils.go
+++ b/util/fileUtils.go
@@ -167,7 +167,12 @@ var GetSpecFiles = func(paths []string) []string {
 			os.Exit(1)
 		}
 		if common.DirExists(path) {
-			specFiles = append(specFiles, FindSpecFilesIn(path)...)
+			specFilesInpath := FindSpecFilesIn(path)
+			if len(specFilesInpath) < 1 {
+				logger.Errorf(true, "No specifications found in %s.", path)
+				os.Exit(1)
+			}
+			specFiles = append(specFiles, specFilesInpath...)
 		} else if common.FileExists(path) && IsValidSpecExtension(path) {
 			f, _ := filepath.Abs(path)
 			specFiles = append(specFiles, f)

--- a/util/fileUtils_test.go
+++ b/util/fileUtils_test.go
@@ -18,6 +18,7 @@
 package util
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -226,6 +227,35 @@ func (s *MySuite) TestGetPathToFile(c *C) {
 
 	path = GetPathToFile("resources")
 	c.Assert(path, Equals, filepath.Join(config.ProjectRoot, "resources"))
+}
+
+func (s *MySuite) TestGetSpecFilesWhenSpecsDirDoesNotExists(c *C) {
+	var expectedErrorMessage string
+	exitWithMessage = func(message string) {
+		expectedErrorMessage = message
+	}
+	GetSpecFiles([]string{"dir1"})
+	c.Assert(expectedErrorMessage, Equals, "Specs directory dir1 does not exists.")
+}
+
+func (s *MySuite) TestGetSpecFilesWhenSpecsDirIsEmpty(c *C) {
+	var expectedErrorMessage string
+	exitWithMessage = func(message string) {
+		expectedErrorMessage = message
+	}
+	GetSpecFiles([]string{dir})
+	c.Assert(expectedErrorMessage, Equals, fmt.Sprintf("No specifications found in %s.", dir))
+}
+
+func (s *MySuite) TestGetSpecFiles(c *C) {
+	expectedSpecFiles := []string{"spec-file-1.spec", "spec-file2.spec"}
+	old := FindSpecFilesIn
+	FindSpecFilesIn = func(dir string) []string {
+		return []string{"spec-file-1.spec", "spec-file2.spec"}
+	}
+	actualSpecFiles := GetSpecFiles([]string{dir})
+	c.Assert(actualSpecFiles, DeepEquals, expectedSpecFiles)
+	FindSpecFilesIn = old
 }
 
 func createFileIn(dir string, fileName string, data []byte) (string, error) {

--- a/version/version.go
+++ b/version/version.go
@@ -25,7 +25,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 0, 7}
+var CurrentGaugeVersion = &Version{1, 0, 8}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
Fixes #1405