### PR TITLE
Fixe for data driven execution when scenario data table are used with parallel tag filters.

### DIFF
--- a/parser/dataTableSpecs.go
+++ b/parser/dataTableSpecs.go
@@ -24,14 +24,16 @@ func GetSpecsForDataTableRows(s []*gauge.Specification, errMap *gauge.BuildError
 				if len(tableRelatedScenarios) > 0 {
 					s := createSpecsForTableRows(spec, tableRelatedScenarios, errMap)
 					s[0].Scenarios = append(s[0].Scenarios, nonTableRelatedScenarios...)
+					for _, scn := range nonTableRelatedScenarios {
+						s[0].Items = append(s[0].Items, scn)
+					}
 					specs = append(specs, s...)
 				} else {
 					specs = append(specs, createSpec(copyScenarios(nonTableRelatedScenarios, gauge.Table{}, 0, errMap), &gauge.Table{}, spec, errMap))
 				}
 			}
 		} else {
-			spec.Scenarios = copyScenarios(spec.Scenarios, gauge.Table{}, 0, errMap)
-			specs = append(specs, spec)
+			specs = append(specs, createSpec(copyScenarios(spec.Scenarios, gauge.Table{}, 0, errMap), &gauge.Table{}, spec, errMap))
 		}
 	}
 	return

--- a/parser/dataTableSpecs_test.go
+++ b/parser/dataTableSpecs_test.go
@@ -117,10 +117,26 @@ func TestGetSpecsForDataTableRowsShouldHaveEqualNumberOfScenearioInSpecsScenario
 		},
 	}
 	actualSpecs := GetSpecsForDataTableRows(specs, gauge.NewBuildErrors())
-
-	if len(actualSpecs[0].Scenarios) != len(actualSpecs[0].Items) {
-		t.Errorf("Failed: Wanted: %d scenarios in items Got: %d scenarios", len(actualSpecs[0].Scenarios), len(actualSpecs[0].Items))
+	if !containsScenario(actualSpecs[0].Scenarios, actualSpecs[0].Items) {
+		itemsJSON, _ := json.Marshal(actualSpecs[0].Items)
+		scnJSON, _ := json.Marshal(actualSpecs[0].Scenarios)
+		t.Errorf("Failed: Wanted items:\n\n%s\n\nto contain all scenarios: \n\n%s", itemsJSON, scnJSON)
 	}
+}
+
+func containsScenario(scenarios []*gauge.Scenario, items []gauge.Item) bool {
+	for _, scenario := range scenarios {
+		contains := false
+		for _, item := range items {
+			if item.Kind() == gauge.ScenarioKind && reflect.DeepEqual(scenario, item.(*gauge.Scenario)) {
+				contains = true
+			}
+		}
+		if !contains {
+			return false
+		}
+	}
+	return true
 }
 
 func TestGetSpecsForDataTableRowsShouldHaveEqualNumberOfScenearioInSpecsScenariosAndItemCollectionForScenarioDataTable(t *testing.T) {
@@ -142,8 +158,10 @@ func TestGetSpecsForDataTableRowsShouldHaveEqualNumberOfScenearioInSpecsScenario
 	}
 	actualSpecs := GetSpecsForDataTableRows(specs, gauge.NewBuildErrors())
 
-	if len(actualSpecs[0].Scenarios) != len(actualSpecs[0].Items) {
-		t.Errorf("Failed: Wanted: %d scenarios in items Got: %d scenarios", len(actualSpecs[0].Scenarios), len(actualSpecs[0].Items))
+	if !containsScenario(actualSpecs[0].Scenarios, actualSpecs[0].Items) {
+		itemsJSON, _ := json.Marshal(actualSpecs[0].Items)
+		scnJSON, _ := json.Marshal(actualSpecs[0].Scenarios)
+		t.Errorf("Failed: Wanted items:\n\n%s\n\nto contain all scenarios: \n\n%s", itemsJSON, scnJSON)
 	}
 	env.AllowScenarioDatatable = old
 }

--- a/parser/dataTableSpecs_test.go
+++ b/parser/dataTableSpecs_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"reflect"
 
+	"github.com/getgauge/gauge/env"
 	"github.com/getgauge/gauge/gauge"
 )
 
@@ -102,6 +103,50 @@ func TestGetSpecsForDataTableRows(t *testing.T) {
 	}
 }
 
+func TestGetSpecsForDataTableRowsShouldHaveEqualNumberOfScenearioInSpecsScenariosAndItemCollection(t *testing.T) {
+	specs := []*gauge.Specification{
+		{
+			Heading: &gauge.Heading{},
+			Scenarios: []*gauge.Scenario{
+				{Steps: []*gauge.Step{{Args: []*gauge.StepArg{{Value: "header", ArgType: gauge.Dynamic, Name: "header"}}}}},
+				{Steps: []*gauge.Step{{Args: []*gauge.StepArg{{Value: "param1", ArgType: gauge.Static, Name: "param1"}}}}},
+			},
+			DataTable: gauge.DataTable{Table: *gauge.NewTable([]string{"header"}, [][]gauge.TableCell{
+				{{Value: "row1", CellType: gauge.Static}, {Value: "row2", CellType: gauge.Static}},
+			}, 0)},
+		},
+	}
+	actualSpecs := GetSpecsForDataTableRows(specs, gauge.NewBuildErrors())
+
+	if len(actualSpecs[0].Scenarios) != len(actualSpecs[0].Items) {
+		t.Errorf("Failed: Wanted: %d scenarios in items Got: %d scenarios", len(actualSpecs[0].Scenarios), len(actualSpecs[0].Items))
+	}
+}
+
+func TestGetSpecsForDataTableRowsShouldHaveEqualNumberOfScenearioInSpecsScenariosAndItemCollectionForScenarioDataTable(t *testing.T) {
+	old := env.AllowScenarioDatatable
+	env.AllowScenarioDatatable = func() bool {
+		return true
+	}
+	specs := []*gauge.Specification{
+		{
+			Heading: &gauge.Heading{},
+			Scenarios: []*gauge.Scenario{
+				{
+					Steps: []*gauge.Step{{Args: []*gauge.StepArg{{Value: "header", ArgType: gauge.Dynamic, Name: "header"}}}},
+					DataTable: gauge.DataTable{Table: *gauge.NewTable([]string{"header"}, [][]gauge.TableCell{
+						{{Value: "row1", CellType: gauge.Static}, {Value: "row2", CellType: gauge.Static}, {Value: "row3", CellType: gauge.Static}},
+					}, 0)}},
+			},
+		},
+	}
+	actualSpecs := GetSpecsForDataTableRows(specs, gauge.NewBuildErrors())
+
+	if len(actualSpecs[0].Scenarios) != len(actualSpecs[0].Items) {
+		t.Errorf("Failed: Wanted: %d scenarios in items Got: %d scenarios", len(actualSpecs[0].Scenarios), len(actualSpecs[0].Items))
+	}
+	env.AllowScenarioDatatable = old
+}
 func TestGetTableWithOneRow(t *testing.T) {
 	table := *gauge.NewTable([]string{"header"}, [][]gauge.TableCell{
 		{{Value: "row1", CellType: gauge.Static}, {Value: "row2", CellType: gauge.Static}},


### PR DESCRIPTION
Fixes #1585

Signed-off-by: Dharmendra Singh <dharmenn@thoughtworks.com>