### PR TITLE
Improve plugin download failure message

### DIFF
--- a/plugin/install/install.go
+++ b/plugin/install/install.go
@@ -406,7 +406,7 @@ func getInstallDescription(plugin string, silent bool) (*installDescription, Ins
 	downloadedFile, downloadErr := util.Download(versionInstallDescriptionJSONUrl, tempDir, versionInstallDescriptionJSONFile, silent)
 	if downloadErr != nil {
 		logger.Debugf(true, "Failed to download %s file: %s", versionInstallDescriptionJSONFile, downloadErr)
-		return nil, installError(fmt.Errorf("Invalid plugin. Could not download %s file.", versionInstallDescriptionJSONFile))
+		return nil, installError(fmt.Errorf("Invalid plugin name or there's a network issue while fetching plugin details."))
 	}
 
 	return getInstallDescriptionFromJSON(downloadedFile)


### PR DESCRIPTION
Fixes: #1583

## Before

```
gauge install invalidplugin
Failed to install plugin 'jasldja'.
Reason: Invalid plugin. Could not download invalidplugin.json file.
```

When offline

```
gauge install java
Failed to install plugin 'java'.
Reason: Invalid plugin. Could not download java-install.json file.
```


## After

```
gauge install invalid
Failed to install plugin 'invalid'.
Reason: Invalid plugin name or there's a network issue while fetching plugin details.
```

while offline

```
gauge install java
Failed to install plugin 'java'.
Reason: Invalid plugin name or there's a network issue while fetching plugin details.
```

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>