### PR TITLE
Fix case of template download failure message

### DIFF
--- a/projectInit/init.go
+++ b/projectInit/init.go
@@ -146,11 +146,11 @@ func Template(name string, silent bool) {
 func fromTemplateName(templateName string, silent bool) {
 	templateURL, err := template.Get(templateName)
 	if err != nil {
-		logger.Fatalf(true, fmt.Errorf("failed to initialize project. %w", err).Error())
+		logger.Fatalf(true, fmt.Errorf("Failed to initialize project. %w", err).Error())
 	}
 	checkURL(templateURL)
 	if err := initializeTemplate(templateURL); err != nil {
-		logger.Fatalf(true, fmt.Errorf("failed to initialize project. %w", err).Error())
+		logger.Fatalf(true, fmt.Errorf("Failed to initialize project. %w", err).Error())
 	}
 	installRunner(silent)
 }

--- a/template/template.go
+++ b/template/template.go
@@ -60,9 +60,9 @@ func (t *templates) get(k string) (string, error) {
 	}
 	matches := t.closestMatch(k)
 	if len(matches) > 0 {
-		return "", fmt.Errorf("cannot find a Gauge template '%s'.\nThe most similar template names are\n\n\t%s", k, strings.Join(matches, "\n\t"))
+		return "", fmt.Errorf("Cannot find a Gauge template '%s'.\nThe most similar template names are\n\n\t%s", k, strings.Join(matches, "\n\t"))
 	}
-	return "", fmt.Errorf("cannot find a Gauge template '%s'", k)
+	return "", fmt.Errorf("Cannot find a Gauge template '%s'", k)
 }
 
 func (t *templates) closestMatch(k string) []string {

--- a/template/template.go
+++ b/template/template.go
@@ -60,9 +60,9 @@ func (t *templates) get(k string) (string, error) {
 	}
 	matches := t.closestMatch(k)
 	if len(matches) > 0 {
-		return "", fmt.Errorf("Cannot find a Gauge template '%s'.\nThe most similar template names are\n\n\t%s", k, strings.Join(matches, "\n\t"))
+		return "", fmt.Errorf("Cannot find Gauge template '%s'.\nThe most similar template names are\n\n\t%s", k, strings.Join(matches, "\n\t"))
 	}
-	return "", fmt.Errorf("Cannot find a Gauge template '%s'", k)
+	return "", fmt.Errorf("Cannot find Gauge template '%s'", k)
 }
 
 func (t *templates) closestMatch(k string) []string {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -106,7 +106,7 @@ func TestGetShouldGetTemplateIfDoesNotExists(t *testing.T) {
 	if e == nil {
 		t.Errorf("expected error. got nil")
 	}
-	expected := "Cannot find a Gauge template 'hello'"
+	expected := "Cannot find Gauge template 'hello'"
 	if e.Error() != expected {
 		t.Errorf("expected error to be \n'%s'\nGot:\n'%s'", expected, e.Error())
 	}
@@ -118,7 +118,7 @@ func TestGetShouldGetSimilarTemplatesIfDoesNotExists(t *testing.T) {
 	if e == nil {
 		t.Errorf("expected error. got nil")
 	}
-	expected := `Cannot find a Gauge template 'jaba'.
+	expected := `Cannot find Gauge template 'jaba'.
 The most similar template names are
 
 	java

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -106,7 +106,7 @@ func TestGetShouldGetTemplateIfDoesNotExists(t *testing.T) {
 	if e == nil {
 		t.Errorf("expected error. got nil")
 	}
-	expected := "cannot find a Gauge template 'hello'"
+	expected := "Cannot find a Gauge template 'hello'"
 	if e.Error() != expected {
 		t.Errorf("expected error to be \n'%s'\nGot:\n'%s'", expected, e.Error())
 	}
@@ -118,7 +118,7 @@ func TestGetShouldGetSimilarTemplatesIfDoesNotExists(t *testing.T) {
 	if e == nil {
 		t.Errorf("expected error. got nil")
 	}
-	expected := `cannot find a Gauge template 'jaba'.
+	expected := `Cannot find a Gauge template 'jaba'.
 The most similar template names are
 
 	java


### PR DESCRIPTION
Make the case consistent with other error messages

### Before

```
$ gauge init js_simple
Error ----------------------------------

[Gauge]
failed to initialize project. cannot find a Gauge template 'js_simple'
```

### After 

```
Error ----------------------------------
$ gauge init js_simple
[Gauge]
Failed to initialize project. Cannot find Gauge template 'js_simple'
```

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>