### PR TITLE
Do not print usage when manifest file is missing

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -79,7 +79,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			logger.Debugf(true, "gauge %s %v", cmd.Name(), strings.Join(args, " "))
 			if err := config.SetProjectRoot(args); err != nil {
-				exit(err, cmd.UsageString())
+				exit(err, "")
 			}
 			if er := handleConflictingParams(cmd.Flags(), args); er != nil {
 				exit(er, "")

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/daviddengcn/go-colortext v0.0.0-20180409174941-186a3d44e920
 	github.com/dmotylev/goproperties v0.0.0-20140630191356-7cbffbaada47
 	github.com/fsnotify/fsnotify v1.4.7
-	github.com/getgauge/common v0.0.0-20200429105102-5b0a7c1a1bd6
+	github.com/getgauge/common v0.0.0-20200824023809-24587c106922
 	github.com/golang/protobuf v1.3.2
 	github.com/golangplus/bytes v1.0.0 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/dmotylev/goproperties v0.0.0-20140630191356-7cbffbaada47 h1:sP2APvSdZ
 github.com/dmotylev/goproperties v0.0.0-20140630191356-7cbffbaada47/go.mod h1:f2V6964+f0p8Asqy8mIK5cKyyVc6MP9PFzGVNRcnYJQ=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/getgauge/common v0.0.0-20200429105102-5b0a7c1a1bd6 h1:A9c4GzoZwS5Z+yx+UszPnnhleF8GtlP1cqjibKKS7qU=
-github.com/getgauge/common v0.0.0-20200429105102-5b0a7c1a1bd6/go.mod h1:e3V+gYeNMZt9gGaHqxwnVAwrewx6uauCqT+IE0vZhM8=
+github.com/getgauge/common v0.0.0-20200824023809-24587c106922 h1:/KwwglTNoofndO0RhEPY750erewl4uAL+WbfN+nLkVs=
+github.com/getgauge/common v0.0.0-20200824023809-24587c106922/go.mod h1:e3V+gYeNMZt9gGaHqxwnVAwrewx6uauCqT+IE0vZhM8=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-check/check v0.0.0-20190902080502-41f04d3bba15 h1:xJdCV5uP69sUzCIIzmhAw6EKKdVk3Tu48oLzM86+XPI=
 github.com/go-check/check v0.0.0-20190902080502-41f04d3bba15/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=

--- a/vendor/github.com/getgauge/common/common.go
+++ b/vendor/github.com/getgauge/common/common.go
@@ -70,7 +70,7 @@ type Property struct {
 func GetProjectRoot() (string, error) {
 	pwd, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("Failed to find project root directory. %s\n", err.Error())
+		return "", fmt.Errorf("Failed to find Gauge project root directory. Missing manifest.json file: %s\n", err.Error())
 	}
 	return findManifestInPath(pwd)
 }
@@ -78,7 +78,7 @@ func GetProjectRoot() (string, error) {
 func findManifestInPath(pwd string) (string, error) {
 	wd, err := filepath.Abs(pwd)
 	if err != nil {
-		return "", fmt.Errorf("Failed to find project directory: %s", err)
+		return "", fmt.Errorf("Failed to find Gauge project directory. Missing manifest.json file: %s", err)
 	}
 	manifestExists := func(dir string) bool {
 		return FileExists(filepath.Join(dir, ManifestFile))
@@ -90,12 +90,12 @@ func findManifestInPath(pwd string) (string, error) {
 			return dir, nil
 		}
 		if dir == filepath.Clean(fmt.Sprintf("%c", os.PathSeparator)) || dir == "" {
-			return "", fmt.Errorf("Failed to find project directory")
+			return "", fmt.Errorf("Failed to find Gauge project directory. Missing manifest.json file.")
 		}
 		oldDir := dir
 		dir = filepath.Clean(fmt.Sprintf("%s%c..", dir, os.PathSeparator))
 		if dir == oldDir {
-			return "", fmt.Errorf("Failed to find project directory")
+			return "", fmt.Errorf("Failed to find Gauge project directory. Missing manifest.json file.")
 		}
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ github.com/daviddengcn/go-colortext
 github.com/dmotylev/goproperties
 # github.com/fsnotify/fsnotify v1.4.7
 github.com/fsnotify/fsnotify
-# github.com/getgauge/common v0.0.0-20200429105102-5b0a7c1a1bd6
+# github.com/getgauge/common v0.0.0-20200824023809-24587c106922
 github.com/getgauge/common
 # github.com/golang/protobuf v1.3.2
 github.com/golang/protobuf/proto


### PR DESCRIPTION
Fixes: #555

### Before

```
$ gauge init js_simple
$ mv manifest.json manifest.json.old
$ gauge run specs
Failed to find project directory
Usage:
  gauge run [flags] [args]

Examples:
  gauge run specs/
  gauge run --tags "login" -s -p specs/

Flags:
  -e, --env string              Specifies the environment to use (default "default")
      --fail-safe               Force return 0 exit code, even in case of failures.
  -f, --failed                  Run only the scenarios failed in previous run. This cannot be used in conjunction with any other argument
  -g, --group int               Specify which group of specification to execute based on -n flag (default -1)
  -h, --help                    Help for run
      --hide-suggestion         Hide step implementation stub for every unimplemented step
  -i, --install-plugins         Install All Missing Plugins (default true)
  -c, --max-retries-count int   Max count of iterations for failed scenario (default 1)
  -n, --n int                   Specify number of parallel execution streams (default 8)
  -p, --parallel                Execute specs in parallel
      --repeat                  Repeat last run. This cannot be used in conjunction with any other argument
      --retry-only string       Retries the specs and scenarios tagged with given tags
      --scenario stringArray    Set scenarios for running specs with scenario name
      --simple-console          Removes colouring and simplifies the console output
  -s, --sort                    Run specs in Alphabetical Order
      --strategy eager          Set the parallelization strategy for execution. Possible options are: eager, `lazy` (default "lazy")
  -r, --table-rows string       Executes the specs and scenarios only for the selected rows. It can be specified by range as 2-4 or as list 2,4
  -t, --tags string             Executes the specs and scenarios tagged with given tags
  -v, --verbose                 Enable step level reporting on console, default being scenario level

Global Flags:
  -d, --dir string         Set the working directory for the current command, accepts a path relative to current directory (default ".")
  -l, --log-level string   Set level of logging to debug, info, warning, error or critical (default "info")
  -m, --machine-readable   Prints output in JSON format

```

### After

```
$ gauge init js_simple
$ mv manifest.json manifest.json.old
$ gauge run specs
Failed to find Gauge project directory. Missing manifest.json file.
```

Note: removed the usage instructions as they are not helpful.

Signed-off-by: Zabil Cheriya Maliackal zabilcm@gmail.com