### PR TITLE
add a placeholder npm/bin/gauge

### DIFF
--- a/build/npm/bin/DO_NOT_DELETE.txt
+++ b/build/npm/bin/DO_NOT_DELETE.txt
@@ -1,0 +1,1 @@
+Required for npm install

--- a/build/npm/src/index.js
+++ b/build/npm/src/index.js
@@ -13,6 +13,8 @@ var downloadFollowingRedirect = function(url, resolve, reject) {
     https.get(url, { headers: { 'accept-encoding': 'gzip,deflate' } }, res => {
         if (res.statusCode >= 300 && res.statusCode < 400) {
             downloadFollowingRedirect(res.headers.location, reject, resolve);
+        } else if (res.statusCode > 400) {
+            console.error(`Unable to download '${url}' : ${res.statusCode}-'${res.statusMessage}'`);
         } else {
             res.pipe(unzip.Extract({ path: path.normalize(binPath) })).on('error', reject).on('end', resolve);
         }

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 1, 2}
+var CurrentGaugeVersion = &Version{1, 1, 3}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
required for npm link

to test:

- clone and checkout this PR
- `cd npm i <path_to_gauge_code>/build/npm`
- run `npm version 1.1.2` (or set any version of gauge to be installed)
- `cd <some work dir>`
- run `npm i <path_to_gauge_code>/build/npm`
- `node_modules/.bin/gauge -v` should print gauge version


Signed-off-by: sriv <srikanth.ddit@gmail.com>
