### PR TITLE
Fix typo and use calmer message

### DIFF
--- a/gauge.go
+++ b/gauge.go
@@ -24,6 +24,6 @@ func main() {
 
 func recoverPanic() {
 	if r := recover(); r != nil {
-		logger.Fatalf(true, "Panicing : %v\n%s", r, string(debug.Stack()))
+		logger.Fatalf(true, "Error: %v\n%s", r, string(debug.Stack()))
 	}
 }


### PR DESCRIPTION
Fix error message typo and use a calmer word
instead of panic

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>