### PR TITLE
Fixes an issue with env variable is to empty string

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -147,7 +147,7 @@ func loadEnvDir(envName string) error {
 func GetProcessedPropertiesMap(propertiesMap *properties.Properties) (*properties.Properties, error) {
 	for propertyKey := range propertiesMap.Map() {
 		// Update properties if an env var is set.
-		if envVarValue, present := os.LookupEnv(propertyKey); present {
+		if envVarValue, present := os.LookupEnv(propertyKey); present && len(envVarValue) > 0 {
 			if _, _, err := propertiesMap.Set(propertyKey, envVarValue); err != nil {
 				return propertiesMap, fmt.Errorf("%s", err.Error())
 			}

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -221,6 +221,19 @@ func (s *MySuite) TestLoadDefaultEnvWithSubstitutedVariables(c *C) {
 	c.Assert(os.Getenv("property2"), Equals, "value1/value2")
 }
 
+func (s *MySuite) TestLoadDefaultEmptyEnvWithSubstitutedVariables(c *C) {
+	os.Clearenv()
+	os.Setenv("property1", "")
+
+	config.ProjectRoot = "_testdata/proj1"
+
+	e := LoadEnv(common.DefaultEnvDir, nil)
+
+	c.Assert(e, Equals, nil)
+
+	c.Assert(os.Getenv("property1"), Equals, "value1")
+}
+
 func (s *MySuite) TestLoadDefaultEnvWithMissingSubstitutedVariable(c *C) {
 	os.Clearenv()
 	config.ProjectRoot = "_testdata/proj5"


### PR DESCRIPTION
Following this change https://github.com/getgauge/gauge/commit/4151d5b48c3973d5d569c565874fa715ce2bf86e

We no longer ignore env var if its set to an empty string.

This change is allow the value from properties file when env var value is an empty string