### PR TITLE
add arm64 plugin support

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 3, 0}
+var CurrentGaugeVersion = &Version{1, 3, 1}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
Plugins, so far, are either platform independent or only support `x86` and `x86_64` arch.

This PR adds plugins targetting `arm64` to be installed.

Signed-off-by: sriv <srikanth.ddit@gmail.com>
