### PR TITLE
Exit with non-zero code if docs plugin has error

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -402,12 +402,12 @@ func GenerateDoc(pluginName string, specDirs []string, startAPIFunc func([]strin
 			logger.Fatalf(true, " %s %s. %s", pd.Name, pd.Version, err.Error())
 		}
 		_, err = p.DocumenterClient.GenerateDocs(context.Background(), getSpecDetails(specDirs))
-		if err != nil {
-			logger.Errorf(true, "Failed to generate docs. %s", err.Error())
+		grpcErr := p.killGrpcProcess()
+		if grpcErr != nil {
+			logger.Errorf(false, "Unable to kill plugin %s : %s", p.descriptor.Name, grpcErr.Error())
 		}
-		err = p.killGrpcProcess()
 		if err != nil {
-			logger.Errorf(false, "Unable to kill plugin %s : %s", p.descriptor.Name, err.Error())
+			logger.Fatalf(true, "Failed to generate docs. %s", err.Error())
 		}
 	} else {
 		port := startAPIFunc(specDirs)

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 4, 0}
+var CurrentGaugeVersion = &Version{1, 4, 1}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
Prior to this commit running a documentation plugin resulted in a zero
exit code even if the plugin explicitly returned an error. This meant
that in a CI/CD pipeline, for instance, the pipeline couldn't check the
exit code and instead had to check the console or log output, which was
brittle.

Fixes #2080

Signed-off-by: John Boyes <154404+johnboyes@users.noreply.github.com>