### PR TITLE
Execute before and after for each spec

### DIFF
--- a/execution/simpleExecution.go
+++ b/execution/simpleExecution.go
@@ -125,12 +125,8 @@ func (e *simpleExecution) executeSpecs(sc *gauge.SpecCollection) (results []*res
 		specs := sc.Next()
 		var preHookFailures, postHookFailures []*gauge_messages.ProtoHookFailure
 		var specResults []*result.SpecResult
-		var before, after = true, false
-		for i, spec := range specs {
-			if i == len(specs)-1 {
-				after = true
-			}
-			res := newSpecExecutor(spec, e.runner, e.pluginHandler, e.errMaps, e.stream).execute(before, preHookFailures == nil, after)
+		for _, spec := range specs {
+			res := newSpecExecutor(spec, e.runner, e.pluginHandler, e.errMaps, e.stream).execute(true, preHookFailures == nil, true)
 			before = false
 			specResults = append(specResults, res)
 			preHookFailures = append(preHookFailures, res.GetPreHook()...)


### PR DESCRIPTION
This pull request aims to fix the issue described in https://github.com/getgauge/gauge/issues/2270. The `before` and `after` actions should always be executed for each spec. Setting these values to `false` actually only makes sense for testing purposes.

Signed-off-by: John Barnes <barnesjohnraymond@gmail.com>