### PR TITLE
Adds gauge_concepts_dir for defining concepts directory 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install Gauge (windows)
         if: matrix.os == 'windows-latest'
         run: |
-          go run build/make.go --install  --verbose
+          go run build/make.go --install --verbose
           echo "C:\\Program Files\\gauge\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install Gauge (linux)
@@ -123,7 +123,7 @@ jobs:
       - name: Install Gauge (windows)
         if: matrix.os == 'windows-latest'
         run: |
-          go run build/make.go --install  --verbose
+          go run build/make.go --install --verbose
           echo "C:\\Program Files\\gauge\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install Gauge (linux)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ If you are trying to write plugins for Gauge or trying to contribute to Gauge co
 Ex:
 ```diff
  // CurrentGaugeVersion represents the current version of Gauge
--var CurrentGaugeVersion = &Version{1, 0, 7}
-+var CurrentGaugeVersion = &Version{1, 0, 8}
+-var CurrentGaugeVersion = &Version{1, 5, 0}
++var CurrentGaugeVersion = &Version{1, 5, 1}
 
 ```

--- a/env/env.go
+++ b/env/env.go
@@ -25,6 +25,8 @@ import (
 const (
 	// SpecsDir holds the location of spec files
 	SpecsDir = "gauge_specs_dir"
+	// ConceptsDir holds the location of concept files
+	ConceptsDir = "gauge_concepts_dir"
 	// GaugeReportsDir holds the location of reports
 	GaugeReportsDir = "gauge_reports_dir"
 	// GaugeEnvironment holds the name of the current environment

--- a/util/_testdata/proj1/env/multipleSpecs/multipleSpecs.properties
+++ b/util/_testdata/proj1/env/multipleSpecs/multipleSpecs.properties
@@ -1,1 +1,2 @@
 gauge_specs_dir=spec1, spec2,    spec3
+gauge_concepts_dir=dir1, dir2,    dir3

--- a/util/fileUtils.go
+++ b/util/fileUtils.go
@@ -178,7 +178,7 @@ func findConceptFiles(paths []string) []string {
 	var conceptFiles []string
 	for _, path := range paths {
 		var conceptPath = strings.TrimSpace(path)
-		if !filepath.IsAbs(conceptPath) && config.ProjectRoot != conceptPath {
+		if !filepath.IsAbs(conceptPath) {
 			conceptPath = filepath.Join(config.ProjectRoot, conceptPath)
 		}
 		absPath, err := filepath.Abs(conceptPath)
@@ -197,7 +197,7 @@ func findConceptFiles(paths []string) []string {
 // It returns concept files from gauge_concepts_dir if present
 // It returns concept files from projectRoot otherwise
 var GetConceptFiles = func() []string {
-	var conceptPaths = GetConceptsPaths()
+	conceptPaths := GetConceptsPaths()
 	if len(conceptPaths) > 0 {
 		return removeDuplicateValues(findConceptFiles(conceptPaths))
 	}
@@ -205,10 +205,11 @@ var GetConceptFiles = func() []string {
 	if projRoot == "" {
 		logger.Fatalf(true, "Failed to get project root.")
 	}
-	files := findConceptFiles([]string{projRoot})
-	var specDirFromProperties = os.Getenv(env.SpecsDir)
+	absProjRoot, _ := filepath.Abs(projRoot)
+	files := findConceptFiles([]string{absProjRoot})
+	specDirFromProperties := os.Getenv(env.SpecsDir)
 	if specDirFromProperties != "" {
-		var specDirectories = strings.Split(specDirFromProperties, ",")
+		specDirectories := strings.Split(specDirFromProperties, ",")
 		files = append(files, findConceptFiles(specDirectories)...)
 	}
 	return removeDuplicateValues(files)

--- a/util/fileUtils.go
+++ b/util/fileUtils.go
@@ -198,11 +198,7 @@ var GetConceptFiles = func() []string {
 		logger.Fatalf(true, "Failed to get project root.")
 	}
 	files := findConceptFiles([]string{projRoot})
-	var specsDirFromProperties = os.Getenv(env.SpecsDir)
-	if specsDirFromProperties != "" {
-		var specDirectories = strings.Split(specsDirFromProperties, ",")
-		files = append(files, findConceptFiles(specDirectories)...)
-	}
+	files = append(files, findConceptFiles(GetSpecDirs())...)
 	return removeDuplicateValues(files)
 }
 

--- a/util/fileUtils_test.go
+++ b/util/fileUtils_test.go
@@ -167,7 +167,7 @@ func (s *MySuite) TestGetConceptFiles(c *C) {
 func (s *MySuite) TestGetConceptFilesWhenSpecDirIsOutsideProjectRoot(c *C) {
 	os.Clearenv()
 	config.ProjectRoot = "_testdata"
-	os.Setenv(env.SpecsDir, "_testSpecDir")
+	os.Setenv(env.SpecsDir, "../_testSpecDir")
 	c.Assert(len(GetConceptFiles()), Equals, 3)
 }
 
@@ -180,24 +180,24 @@ func (s *MySuite) TestGetConceptFilesWhenSpecDirIsWithInProject(c *C) {
 
 func (s *MySuite) TestGetConceptFilesWhenConceptsDirSet(c *C) {
 	os.Clearenv()
-	config.ProjectRoot = "_testdata/specs"
+	config.ProjectRoot = "_testdata"
 	c.Assert(len(GetConceptFiles()), Equals, 2)
 
-	config.ProjectRoot = "_testdata"
-	os.Setenv(env.ConceptsDir, filepath.Join("_testdata", "specs", "concept1.cpt"))
+	os.Setenv(env.ConceptsDir, filepath.Join("specs", "concept1.cpt"))
 	c.Assert(len(GetConceptFiles()), Equals, 1)
 
-	os.Setenv(env.ConceptsDir, filepath.Join("_testdata", "specs", "subdir"))
+	os.Setenv(env.ConceptsDir, filepath.Join("specs", "subdir"))
 	c.Assert(len(GetConceptFiles()), Equals, 1)
 
-	os.Setenv(env.ConceptsDir, filepath.Join("_testdata", "specs", "subdir", "concept2.cpt"))
+	conceptPath, _ := filepath.Abs(filepath.Join("_testdata", "specs", "subdir", "concept2.cpt"))
+	os.Setenv(env.ConceptsDir, conceptPath)
 	c.Assert(len(GetConceptFiles()), Equals, 1)
 }
 
 func (s *MySuite) TestGetConceptFilesWhenConceptDirIsOutsideProjectRoot(c *C) {
 	os.Clearenv()
 	config.ProjectRoot = "_testdata"
-	os.Setenv(env.ConceptsDir, "_testSpecDir,_testdata/specs")
+	os.Setenv(env.ConceptsDir, "../_testSpecDir,../_testdata/specs")
 	c.Assert(len(GetConceptFiles()), Equals, 3)
 }
 
@@ -285,6 +285,25 @@ func (s *MySuite) TestGetSpecFilesWhenSpecsDirDoesNotExists(c *C) {
 	}
 	GetSpecFiles([]string{"dir1"})
 	c.Assert(expectedErrorMessage, Equals, "Specs directory dir1 does not exist.")
+}
+
+func (s *MySuite) TestGetConceptFilesWhenConceptsDirDoesNotExists(c *C) {
+	os.Clearenv()
+	var expectedErrorMessage string
+	exitWithMessage = func(message string) {
+		expectedErrorMessage = message
+	}
+	config.ProjectRoot = "_testdata"
+
+	os.Setenv(env.SpecsDir, "specs2")
+	GetConceptFiles()
+	directory, _ := filepath.Abs(filepath.Join(config.ProjectRoot, "specs2"))
+	c.Assert(expectedErrorMessage, Equals, fmt.Sprintf("No such file or diretory: %s", directory))
+
+	os.Setenv(env.SpecsDir, "_testSpecsDir,non-exisitng")
+	GetConceptFiles()
+	directory, _ = filepath.Abs(filepath.Join(config.ProjectRoot, "non-exisitng"))
+	c.Assert(expectedErrorMessage, Equals, fmt.Sprintf("No such file or diretory: %s", directory))
 }
 
 func (s *MySuite) TestGetSpecFilesWhenSpecsDirIsEmpty(c *C) {

--- a/util/fileUtils_test.go
+++ b/util/fileUtils_test.go
@@ -147,6 +147,7 @@ func (s *MySuite) TestFindAllConceptFilesInNestedDir(c *C) {
 }
 
 func (s *MySuite) TestGetConceptFiles(c *C) {
+	os.Clearenv()
 	config.ProjectRoot = "_testdata"
 	specsDir, _ := filepath.Abs(filepath.Join("_testdata", "specs"))
 
@@ -164,15 +165,40 @@ func (s *MySuite) TestGetConceptFiles(c *C) {
 }
 
 func (s *MySuite) TestGetConceptFilesWhenSpecDirIsOutsideProjectRoot(c *C) {
+	os.Clearenv()
 	config.ProjectRoot = "_testdata"
 	os.Setenv(env.SpecsDir, "_testSpecDir")
 	c.Assert(len(GetConceptFiles()), Equals, 3)
 }
 
 func (s *MySuite) TestGetConceptFilesWhenSpecDirIsWithInProject(c *C) {
+	os.Clearenv()
 	config.ProjectRoot = "_testdata"
 	os.Setenv(env.SpecsDir, "_testdata/specs")
 	c.Assert(len(GetConceptFiles()), Equals, 2)
+}
+
+func (s *MySuite) TestGetConceptFilesWhenConceptsDirSet(c *C) {
+	os.Clearenv()
+	config.ProjectRoot = "_testdata/specs"
+	c.Assert(len(GetConceptFiles()), Equals, 2)
+
+	config.ProjectRoot = "_testdata"
+	os.Setenv(env.ConceptsDir, filepath.Join("_testdata", "specs", "concept1.cpt"))
+	c.Assert(len(GetConceptFiles()), Equals, 1)
+
+	os.Setenv(env.ConceptsDir, filepath.Join("_testdata", "specs", "subdir"))
+	c.Assert(len(GetConceptFiles()), Equals, 1)
+
+	os.Setenv(env.ConceptsDir, filepath.Join("_testdata", "specs", "subdir", "concept2.cpt"))
+	c.Assert(len(GetConceptFiles()), Equals, 1)
+}
+
+func (s *MySuite) TestGetConceptFilesWhenConceptDirIsOutsideProjectRoot(c *C) {
+	os.Clearenv()
+	config.ProjectRoot = "_testdata"
+	os.Setenv(env.ConceptsDir, "_testSpecDir,_testdata/specs")
+	c.Assert(len(GetConceptFiles()), Equals, 3)
 }
 
 func (s *MySuite) TestFindAllNestedDirs(c *C) {

--- a/util/util.go
+++ b/util/util.go
@@ -110,6 +110,21 @@ func GetSpecDirs() []string {
 	return []string{common.SpecsDirectoryName}
 }
 
+// GetConceptsPaths returns the concepts directory.
+// It checks whether the environment variable for gauge_concepts_dir is set.
+// It returns specs directories otherwise
+func GetConceptsPaths() []string {
+	var conceptDirs []string
+	var conceptsDirFromProperties = os.Getenv(env.ConceptsDir)
+	if conceptsDirFromProperties != "" {
+		conceptDirs = strings.Split(conceptsDirFromProperties, ",")
+		for index, ele := range conceptDirs {
+			conceptDirs[index] = strings.TrimSpace(ele)
+		}
+	}
+	return conceptDirs
+}
+
 func ListContains(list []string, val string) bool {
 	for _, s := range list {
 		if s == val {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -16,3 +16,9 @@ func (s *MySuite) TestSpecDirEnvVariableAllowsCommaSeparatedList(c *C) {
 	c.Assert(e, Equals, nil)
 	c.Assert(GetSpecDirs(), DeepEquals, []string{"spec1", "spec2", "spec3"})
 }
+
+func (s *MySuite) TestConceptsDirEnvVariableAllowsCommaSeparatedList(c *C) {
+	os.Clearenv()
+	os.Setenv(env.ConceptsDir, "dir1, dir2,    dir3")
+	c.Assert(GetConceptsPaths(), DeepEquals, []string{"dir1", "dir2", "dir3"})
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -16,3 +16,9 @@ func (s *MySuite) TestSpecDirEnvVariableAllowsCommaSeparatedList(c *C) {
 	c.Assert(e, Equals, nil)
 	c.Assert(GetSpecDirs(), DeepEquals, []string{"spec1", "spec2", "spec3"})
 }
+
+func (s *MySuite) TestConceptsDirEnvVariableAllowsCommaSeparatedList(c *C) {
+	os.Clearenv()
+	os.Setenv(env.ConceptsDir, "path1, path2,    path3")
+	c.Assert(GetConceptsPaths(), DeepEquals, []string{"path1", "path2", "path3"})
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -16,9 +16,3 @@ func (s *MySuite) TestSpecDirEnvVariableAllowsCommaSeparatedList(c *C) {
 	c.Assert(e, Equals, nil)
 	c.Assert(GetSpecDirs(), DeepEquals, []string{"spec1", "spec2", "spec3"})
 }
-
-func (s *MySuite) TestConceptsDirEnvVariableAllowsCommaSeparatedList(c *C) {
-	os.Clearenv()
-	os.Setenv(env.ConceptsDir, "path1")
-	c.Assert(GetConceptsPaths(), DeepEquals, []string{"path1"})
-}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -16,9 +16,3 @@ func (s *MySuite) TestSpecDirEnvVariableAllowsCommaSeparatedList(c *C) {
 	c.Assert(e, Equals, nil)
 	c.Assert(GetSpecDirs(), DeepEquals, []string{"spec1", "spec2", "spec3"})
 }
-
-func (s *MySuite) TestConceptsDirEnvVariableAllowsCommaSeparatedList(c *C) {
-	os.Clearenv()
-	os.Setenv(env.ConceptsDir, "dir1, dir2,    dir3")
-	c.Assert(GetConceptsPaths(), DeepEquals, []string{"dir1", "dir2", "dir3"})
-}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -16,3 +16,10 @@ func (s *MySuite) TestSpecDirEnvVariableAllowsCommaSeparatedList(c *C) {
 	c.Assert(e, Equals, nil)
 	c.Assert(GetSpecDirs(), DeepEquals, []string{"spec1", "spec2", "spec3"})
 }
+
+func (s *MySuite) TestConceptsDirEnvVariableAllowsCommaSeparatedList(c *C) {
+	c.Skip("This is causing the net/httptest panic in httpUtils_test fail on windows.")
+	os.Clearenv()
+	os.Setenv(env.ConceptsDir, "path1")
+	c.Assert(GetConceptsPaths(), DeepEquals, []string{"path1"})
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -18,8 +18,11 @@ func (s *MySuite) TestSpecDirEnvVariableAllowsCommaSeparatedList(c *C) {
 }
 
 func (s *MySuite) TestConceptsDirEnvVariableAllowsCommaSeparatedList(c *C) {
-	c.Skip("This is causing the net/httptest panic in httpUtils_test fail on windows.")
+	c.Skip("This is causing the net/httptest panic in util/httpUtils_test.go fail on windows.")
 	os.Clearenv()
-	os.Setenv(env.ConceptsDir, "path1")
-	c.Assert(GetConceptsPaths(), DeepEquals, []string{"path1"})
+	config.ProjectRoot = "_testdata/proj1"
+
+	e := env.LoadEnv("multipleSpecs", nil)
+	c.Assert(e, Equals, nil)
+	c.Assert(GetConceptsPaths(), DeepEquals, []string{"dir1", "dir2", "dir3"})
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -19,6 +19,6 @@ func (s *MySuite) TestSpecDirEnvVariableAllowsCommaSeparatedList(c *C) {
 
 func (s *MySuite) TestConceptsDirEnvVariableAllowsCommaSeparatedList(c *C) {
 	os.Clearenv()
-	os.Setenv(env.ConceptsDir, "path1, path2,    path3")
-	c.Assert(GetConceptsPaths(), DeepEquals, []string{"path1", "path2", "path3"})
+	os.Setenv(env.ConceptsDir, "path1")
+	c.Assert(GetConceptsPaths(), DeepEquals, []string{"path1"})
 }

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 5, 1}
+var CurrentGaugeVersion = &Version{1, 5, 2}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
Fixes https://github.com/getgauge/gauge/issues/2311

By default, gauge searches with both `<project root>` and `gauge_specs_dir` for searching and validating the concepts. 

This change is adding a new `gauge_concepts_dir` property so that so we can limit the concepts validation to specific directories. If this isn't set, then current behaviour applies for backward compatibility.

Documentation: https://github.com/getgauge/docs.gauge.org/pull/338