### PR TITLE
Uncomments out a fixed unit test

### DIFF
--- a/filter/specItemFilter_test.go
+++ b/filter/specItemFilter_test.go
@@ -20,13 +20,8 @@ type MySuite struct{}
 
 var _ = Suite(&MySuite{})
 
-func before()  {
-	os.Clearenv()
+func before() {
 	os.Setenv("allow_case_sensitive_tags", "false")
-}
-
-func after() {
-	os.Clearenv()
 }
 
 func (s *MySuite) TestToEvaluateTagExpressionWithTwoTags(c *C) {
@@ -536,7 +531,6 @@ func (s *MySuite) TestFilterTags(c *C) {
 
 func (s *MySuite) TestFilterMixedCaseTags(c *C) {
 	before()
-	defer after()
 	specTags := []string{"abcd", "foo", "BAR", "foo bar"}
 	tagFilter := NewScenarioFilterBasedOnTags(specTags, "abcd & FOO bar")
 	evaluateTrue := tagFilter.filterTags(specTags)
@@ -552,7 +546,6 @@ func (s *MySuite) TestSanitizeTags(c *C) {
 
 func (s *MySuite) TestSanitizeMixedCaseTags(c *C) {
 	before()
-	defer after()
 	specTags := []string{"abcd", "foo", "bar", "foo bar"}
 	tagFilter := NewScenarioFilterBasedOnTags(specTags, "abcd & foo Bar | true")
 	evaluateTrue := tagFilter.filterTags(specTags)
@@ -612,7 +605,6 @@ func (s *MySuite) TestToFilterSpecsByTags(c *C) {
 
 func (s *MySuite) TestToFilterSpecsByMixedCaseTags(c *C) {
 	before()
-	defer after()
 	myTags := []string{"tag1", "TAG2"}
 	scenario1 := &gauge.Scenario{
 		Heading: &gauge.Heading{Value: "First Scenario"},
@@ -701,7 +693,6 @@ func (s *MySuite) TestToFilterScenariosByTag(c *C) {
 
 func (s *MySuite) TestToFilterScenariosByMixedCaseTag(c *C) {
 	before()
-	defer after()
 	myTags := []string{"Tag-1", "tag2"}
 
 	scenario1 := &gauge.Scenario{

--- a/util/fileUtils_test.go
+++ b/util/fileUtils_test.go
@@ -33,6 +33,8 @@ func (s *MySuite) SetUpTest(c *C) {
 func (s *MySuite) TearDownTest(c *C) {
 	err := os.RemoveAll(dir)
 	c.Assert(err, Equals, nil)
+	c.Assert(os.Unsetenv(env.SpecsDir), Equals, nil)
+	c.Assert(os.Unsetenv(env.ConceptsDir), Equals, nil)
 }
 
 func (s *MySuite) TestFindAllSpecFiles(c *C) {
@@ -147,7 +149,6 @@ func (s *MySuite) TestFindAllConceptFilesInNestedDir(c *C) {
 }
 
 func (s *MySuite) TestGetConceptFiles(c *C) {
-	os.Clearenv()
 	config.ProjectRoot = "_testdata"
 	specsDir, _ := filepath.Abs(filepath.Join("_testdata", "specs"))
 
@@ -165,21 +166,18 @@ func (s *MySuite) TestGetConceptFiles(c *C) {
 }
 
 func (s *MySuite) TestGetConceptFilesWhenSpecDirIsOutsideProjectRoot(c *C) {
-	os.Clearenv()
 	config.ProjectRoot = "_testdata"
 	os.Setenv(env.SpecsDir, "../_testSpecDir")
 	c.Assert(len(GetConceptFiles()), Equals, 3)
 }
 
 func (s *MySuite) TestGetConceptFilesWhenSpecDirIsWithInProject(c *C) {
-	os.Clearenv()
 	config.ProjectRoot = "_testdata"
 	os.Setenv(env.SpecsDir, "_testdata/specs")
 	c.Assert(len(GetConceptFiles()), Equals, 2)
 }
 
 func (s *MySuite) TestGetConceptFilesWhenConceptsDirSet(c *C) {
-	os.Clearenv()
 	config.ProjectRoot = "_testdata"
 	c.Assert(len(GetConceptFiles()), Equals, 2)
 
@@ -195,7 +193,6 @@ func (s *MySuite) TestGetConceptFilesWhenConceptsDirSet(c *C) {
 }
 
 func (s *MySuite) TestGetConceptFilesWhenConceptDirIsOutsideProjectRoot(c *C) {
-	os.Clearenv()
 	config.ProjectRoot = "_testdata"
 	os.Setenv(env.ConceptsDir, "../_testSpecDir,../_testdata/specs")
 	c.Assert(len(GetConceptFiles()), Equals, 3)
@@ -288,7 +285,6 @@ func (s *MySuite) TestGetSpecFilesWhenSpecsDirDoesNotExists(c *C) {
 }
 
 func (s *MySuite) TestGetConceptFilesWhenConceptsDirDoesNotExists(c *C) {
-	os.Clearenv()
 	var expectedErrorMessage string
 	exitWithMessage = func(message string) {
 		expectedErrorMessage = message

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -4,11 +4,9 @@ import (
 	"github.com/getgauge/gauge/config"
 	"github.com/getgauge/gauge/env"
 	. "gopkg.in/check.v1"
-	"os"
 )
 
 func (s *MySuite) TestSpecDirEnvVariableAllowsCommaSeparatedList(c *C) {
-	os.Clearenv()
 	config.ProjectRoot = "_testdata/proj1"
 
 	e := env.LoadEnv("multipleSpecs", nil)

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,11 +1,10 @@
 package util
 
 import (
-	"os"
-
 	"github.com/getgauge/gauge/config"
 	"github.com/getgauge/gauge/env"
 	. "gopkg.in/check.v1"
+	"os"
 )
 
 func (s *MySuite) TestSpecDirEnvVariableAllowsCommaSeparatedList(c *C) {
@@ -18,8 +17,6 @@ func (s *MySuite) TestSpecDirEnvVariableAllowsCommaSeparatedList(c *C) {
 }
 
 func (s *MySuite) TestConceptsDirEnvVariableAllowsCommaSeparatedList(c *C) {
-	c.Skip("This is causing the net/httptest panic in util/httpUtils_test.go fail on windows.")
-	os.Clearenv()
 	config.ProjectRoot = "_testdata/proj1"
 
 	e := env.LoadEnv("multipleSpecs", nil)


### PR DESCRIPTION
Changes:

- Uncomments a unit test failing due to the use of os.Clearenv()
- Removes the use of os.Clearenv() from the utils package

