### PR TITLE
Fix download timeout on node v20 install

### DIFF
--- a/build/npm/src/index.js
+++ b/build/npm/src/index.js
@@ -25,8 +25,10 @@ var downloadFollowingRedirect = function(url, resolve, reject) {
     https.get(url, { headers: { 'accept-encoding': 'gzip,deflate' } }, res => {
         if (res.statusCode >= 300 && res.statusCode < 400) {
             downloadFollowingRedirect(res.headers.location, resolve, reject);
+            res.resume()
         } else if (res.statusCode >= 400) {
             reject(new Error(`Unable to download '${url}' : ${res.statusCode}-'${res.statusMessage}'`));
+            res.resume()
         } else {
             const chunks = [];
             res

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 5, 3}
+var CurrentGaugeVersion = &Version{1, 5, 4}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
This is a fix for #2332 for node v20, see https://github.com/getgauge/gauge/pull/2332#issuecomment-1608649427

In node v20 the process hangs until the request times out caused by not consumed response data. Users might get the impression that the installation fails. This behavior is not observable for node v18, v16, v14, v12, v10.

From [nodes docs](https://nodejs.org/api/http.html#class-httpclientrequest):

> if a ['response'](https://nodejs.org/api/http.html#event-response) event handler is added, then the data from the response object must be consumed, either by calling `response.read()` whenever there is a 'readable' event, or by adding a 'data' handler, or by calling the `.resume()` method

This PR fixes the installation delay by adding `res.resume()` calls.

How to reproduce:

Output for 

```
docker run -ti --rm node:18-alpine /bin/sh
mkdir /app
cd /app
npm init -y
time npm i @getgauge/cli
```

is

```
# time npm i @getgauge/cli

added 2 packages, and audited 3 packages in 5s

found 0 vulnerabilities
npm notice 
npm notice New minor version of npm available! 9.6.7 -> 9.8.1
npm notice Changelog: https://github.com/npm/cli/releases/tag/v9.8.1
npm notice Run npm install -g npm@9.8.1 to update!
npm notice 
real	0m 5.20s
user	0m 0.81s
sys	0m 0.26s
```

for node v20, the times are
```
real	2m 3.35s
user	0m 2.82s
sys	0m 1.14s
```