### PR TITLE
Fix method comment

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -112,7 +112,7 @@ func GetSpecDirs() []string {
 
 // GetConceptsPaths returns the concepts directory.
 // It checks whether the environment variable for gauge_concepts_dir is set.
-// It returns specs directories otherwise
+// It returns an empty list (of directories) otherwise
 func GetConceptsPaths() []string {
 	var conceptDirs []string
 	var conceptsDirFromProperties = os.Getenv(env.ConceptsDir)


### PR DESCRIPTION
The method `GetConceptsPaths` does not return `specs` if the concepts dir is not set in the current env.

Related to #2311