### PR TITLE
Fix Gauge release brew+Github workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,22 +134,8 @@ jobs:
           echo -e "Gauge v$GAUGE_VERSION\n\n" > desc.txt
           release_description=$(ruby -e "$(curl -sSfL https://github.com/getgauge/gauge/raw/master/build/create_release_text.rb)" getgauge gauge)
           echo "$release_description" >> desc.txt
-          echo "Creating new draft for release v$GAUGE_VERSION"
-          hub release create -F ./desc.txt "v$GAUGE_VERSION"
-          rm -rf desc.txt
-          sleep 10
+          gh release create --title "Gauge v$GAUGE_VERSION" --notes-file ./desc.txt "v$GAUGE_VERSION" ./gauge-*
 
-          echo "---------------------------"
-          echo "Uploading artifacts"
-          echo "---------------------------"
-
-          for artifact in `ls gauge-*`; do
-            echo $artifact
-            hub release edit -m "" -a $artifact v$GAUGE_VERSION
-            if [ $? -ne 0 ]; then
-                exit 1
-            fi
-          done
 
   pypi-release:
     runs-on: ubuntu-latest

--- a/build/brew/create_brew_pr.sh
+++ b/build/brew/create_brew_pr.sh
@@ -26,9 +26,9 @@ git branch -D $BRANCH || true
 git checkout -b $BRANCH
 
 gem install parser
-ruby ../brew_update.rb $GAUGE_VERSION ./Formula/gauge.rb
+ruby ../brew_update.rb $GAUGE_VERSION ./Formula/g/gauge.rb
 
-git add ./Formula/gauge.rb
+git add ./Formula/g/gauge.rb
 git commit -m "gauge $GAUGE_VERSION"
 git push -f "https://$HOMEBREW_GITHUB_USER_NAME:$GITHUB_TOKEN@github.com/$HOMEBREW_GITHUB_USER_NAME/homebrew-core.git" "gauge-$GAUGE_VERSION"
 


### PR DESCRIPTION
Oof, the release [workflow failed](https://github.com/getgauge/gauge/actions/runs/6652744383) so it's a mess.

* GitHub [release failed](https://github.com/getgauge/gauge/actions/runs/6652744383/job/18077911869) as `hub` is gone now: https://github.com/actions/runner-images/issues/8362 - need to 
  * migrate to `gh` (which this PR does). See [gh release upload](https://cli.github.com/manual/gh_release_upload).
  * OR re-install via `sudo apt-get update && sudo apt-get install -y hub`
* Brew formulae were sharded in https://github.com/Homebrew/homebrew-core/pull/139592

@haroon-sheikh @zabil do you know if the rest of the [release workflows](https://github.com/getgauge/gauge/actions/runs/6652744383) are idempotent and can be re-run? (pypi, npm, choco)

(_edit_: I **think** I can probably just merge this with version `1.5.5` as-is, then cancel the three "_already run_" workflow jobs to avoid them messing anything up and allow the two failed ones to re-run - as there doesn't seem to be anything upstream or downstream that is dependent?)

Or I'll need to bump the version again, hope it works and otherwise just deal with the missing GH tag/release notes etc for `1.5.5`?