### PR TITLE
feat: add version parameter for download script

### DIFF
--- a/build/download.sh
+++ b/build/download.sh
@@ -12,11 +12,17 @@ download() {
     tmp="$(ensure mktemp -d)"
     ensure cd "$tmp"
 
-    # Download latest Gauge zip installer
-    url="$(ensure curl -Ss https://api.github.com/repos/getgauge/gauge/releases/latest \
-    | grep "browser_download_url.*$OS.$ARCH.zip" \
-    | cut -d : -f 2,3 \
-    | tr -d \")"
+    # set api url
+    if [ $VERSION = "latest" ]; then
+        api_url="https://api.github.com/repos/getgauge/gauge/releases/latest"
+    else
+        api_url="https://api.github.com/repos/getgauge/gauge/releases/tags/$VERSION"
+    fi
+    # set download url
+    url="$(ensure curl -Ss $api_url \
+        | grep "browser_download_url.*$OS.$ARCH.zip" \
+        | cut -d : -f 2,3 \
+        | tr -d \")"
 
     say "Downloading binary from URL:$url"
     ensure curl -L -o gauge.zip $url
@@ -109,6 +115,7 @@ set_os_architecture() {
 
 handle_cmd_line_args() {
     LOCATION="/usr/local/bin"
+    VERSION="latest"
     for _arg in "$@"; do
         case "${_arg%%=*}" in
             --verbose)
@@ -117,6 +124,11 @@ handle_cmd_line_args() {
             --location)
                 if is_value_arg "$_arg" "location"; then
                     LOCATION="$(get_value_arg "$_arg")"
+                fi
+                ;;
+            --version)
+                if is_value_arg "$_arg" "version"; then
+                    VERSION="$(get_value_arg "$_arg")"
                 fi
                 ;;
         esac


### PR DESCRIPTION
The current download script is always downloading the [latest](https://github.com/getgauge/gauge/blob/62b9937c03b9d29d2e9f94c0778defce9afc6c4c/build/download.sh#L16) available release.
This MR adds the optional possibility to specify the version you want to install explicitly. The version defaults to `latest` , if its not provided.

```
--version=v1.5.6
```