### PR TITLE
Send ConceptEnd notification when concept step fails

### DIFF
--- a/execution/scenarioExecutor.go
+++ b/execution/scenarioExecutor.go
@@ -214,6 +214,12 @@ func (e *scenarioExecutor) executeConcept(item *gauge.Step, protoConcept *gauge_
 				if recoverable {
 					continue
 				}
+				// The concept is finishing after a step failure
+				// Restore the Concept step data in the Execution info that is sent to plugins
+				e.currentExecutionInfo.CurrentStep = &gauge_messages.StepInfo{Step: stepRequest, IsFailed: false}
+				defer event.Notify(event.NewExecutionEvent(event.ConceptEnd, nil, cptResult, e.stream, e.currentExecutionInfo))
+				defer e.notifyAfterConcept(scenarioResult)
+
 				return cptResult
 			}
 		}

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 0}
+var CurrentGaugeVersion = &Version{1, 6, 1}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
Send ConceptEnd notification (NotifyConceptExecutionEnding) when a concept step fails and the concept is then finishing.

Other reasons for this update:
 - consistency - ConceptEnd is sent when a concept finishes both successfully and when a concept step fails
 - ConceptEnd must be sent on concept step failure when there are Scenario Teardown steps. Without this notification the teardown steps are perceived to be part of the concept which is not correct 