### PR TITLE
Fix chocolatey package releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,7 +209,7 @@ jobs:
 
   choco-release:
     runs-on: windows-latest
-    needs: [gauge-version]
+    needs: [gauge-version, windows-package]
     steps:
       - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow
@@ -219,6 +219,11 @@ jobs:
         with:
           name: gauge-version
           path: .
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: gauge-windows-artifact
+          path: ./deploy
 
       - name: Set gauge version
         run: echo "GAUGE_VERSION=`cat version.txt`" >> $GITHUB_ENV


### PR DESCRIPTION
The Chocolatey packages are stuck in moderation since they currently download/install packages without checksums: https://community.chocolatey.org/packages/gauge/1.5.7 

> Package automation scripts download a remote file without validating the checksum.

This change makes the Windows packages available to the Choco package release step, since the checksums don't seem to be in some other metadata.

Checksums are mandatory within Chocolatey packages now so these are needed to be able to generate the package install script. Dependent on https://github.com/getgauge/chocolatey-packages/commit/406b9d7614163c6f21de723737bd3e028783df34 which computes the checksums and changes the templating of the package accordingly, so you get a `chocolateyInstall.ps1` like

```powershell
$packageName = 'gauge'
$location = "$env:PROGRAMFILES\gauge\bin"
$validExitCodes = @(0)

Install-ChocolateyZipPackage -PackageName "$packageName" -Url "https://github.com/getgauge/gauge/releases/download/v1.6.1/gauge-1.6.1-windows.x86.zip" -Checksum "54ffb0dc379fb565c3032a0f7bd928b6114fd13e20f335e114ff9b6f08fd2f83" -ChecksumType sha256 -Url64 "https://github.com/getgauge/gauge/releases/download/v1.6.1/gauge-1.6.1-windows.x86_64.zip" -Checksum64 "fa78e558853a7e6b5618cd3db3bc7994650a33fa756c74f3fa08d2cbd7bcfe67" -ChecksumType64 sha256 -UnzipLocation "$location" -validExitCodes $validExitCodes

$currentPath = [environment]::GetEnvironmentVariable("PATH", "Machine")

if($currentPath -NotLike "*$location*") {
    $newPath = $currentPath + ";" + "$location"
    [environment]::SetEnvironmentVariable("PATH", $newPath, "Machine")
}
```

The `package.ps1` for generation has been validated on Windows 11.