### PR TITLE
Adds the option to specify env for validate

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -19,10 +19,11 @@ const (
 
 var (
 	validateCmd = &cobra.Command{
-		Use:     "validate [flags] [args]",
-		Short:   "Check for validation and parse errors",
-		Long:    `Check for validation and parse errors.`,
-		Example: "  gauge validate specs/",
+		Use:   "validate [flags] [args]",
+		Short: "Check for validation and parse errors",
+		Long:  `Check for validation and parse errors.`,
+		Example: `  gauge validate specs/
+  gauge validate --env test specs/`,
 		Run: func(cmd *cobra.Command, args []string) {
 			validation.HideSuggestion = hideSuggestion
 			if err := config.SetProjectRoot(args); err != nil {
@@ -39,5 +40,7 @@ var (
 
 func init() {
 	GaugeCmd.AddCommand(validateCmd)
-	validateCmd.Flags().BoolVarP(&hideSuggestion, "hide-suggestion", "", false, "Prints a step implementation stub for every unimplemented step")
+	flags := validateCmd.Flags()
+	flags.BoolVarP(&hideSuggestion, "hide-suggestion", "", false, "Prints a step implementation stub for every unimplemented step")
+	flags.StringVarP(&environment, environmentName, "e", environmentDefault, "Specifies the environment to use")
 }

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 4}
+var CurrentGaugeVersion = &Version{1, 6, 5}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 5}
+var CurrentGaugeVersion = &Version{1, 6, 4}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
Relates to https://github.com/getgauge/gauge/issues/2244

- Adds the option to specify env for validate so that it can use the correct gauge_data_dir for validating the specs.

**Note:**
We cannot filter the validation by tags because to filter the specs, we have to parse them which in return throws the validation errors.