### PR TITLE
Fix PyPi getgauge-cli publishing

### DIFF
--- a/build/pip/README.md
+++ b/build/pip/README.md
@@ -1,20 +1,17 @@
 # PIP Installer for getgauge-cli tool
 
-This `setup.py` file is used for installed getgauge-cli tool.
-the version number is manually bumped for now.
+This `setup.py` file is used for installing the getgauge-cli tool. The Python package can be installed multiple ways:
 
-Python package can be installed through multiple ways
+## using pip
+
+- pre-requisite: pip should be installed and available on machine
+- run the command `pip install getgauge-cli`
 
 ## using setup.py
 
 - Navigate to the current directory `gauge\build\pip\`
 - Run `python build.py --install` on command prompt (it will install the latest released version)
 - To install a specific version set `GAUGE_VERSION` environment variable.
-
-## using pip
-
-- pre-requisite: pip should be installed and available on machine
-- run the command `pip install getgauge-cli`
 
 ## Check to ensure getgauge-cli is installed
 
@@ -24,35 +21,7 @@ Python package can be installed through multiple ways
 Usage:
   gauge <command> [flags] [args]
 
-Examples:
-  gauge run specs/
-  gauge run --parallel specs/
-
-Commands:
-  config      Change global configurations
-  daemon      Run as a daemon
-  docs        Generate documentation using specified plugin
-  format      Formats the specified spec files
-  help        Help about any command
-  init        Initialize project structure in the current directory
-  install     Download and install plugin(s)
-  list        List specifications, scenarios or tags for a gauge project
-  man         Generate man pages
-  run         Run specs
-  uninstall   Uninstalls a plugin
-  update      Updates a plugin
-  validate    Check for validation and parse errors
-  version     Print Gauge and plugin versions
-
-Flags:
-  -d, --dir string         Set the working directory for the current command, accepts a path relative to current directory (default ".")
-  -h, --help               Help for gauge
-  -l, --log-level string   Set level of logging to debug, info, warning, error or critical (default "info")
-  -m, --machine-readable   Prints output in JSON format
-  -v, --version            Print Gauge and plugin versions
-
-Use "gauge [command] --help" for more information about a command.
-Complete manual is available at https://manpage.gauge.org/.
+# ...etc
 ```
 
 ## Using setup.py
@@ -61,7 +30,7 @@ Complete manual is available at https://manpage.gauge.org/.
 - Run the command `python build.py --install` (set GAUGE_VERSION env to install specific version)
 - This would install the version as specified along with latest release of Gauge-CLI Version
 
-- Run the command `python build.py --dist` to generate the PyPi distrubutable (set GAUGE_VERSION env to install specific version)
+- Run the command `python build.py --dist` to generate the PyPi distributable (set GAUGE_VERSION env to install specific version)
 
 ## Uninstalling Gauge CLI
 

--- a/build/pip/requirements.txt
+++ b/build/pip/requirements.txt
@@ -16,6 +16,7 @@ requests==2.31.0
 requests-toolbelt==1.0.0
 rfc3986==2.0.0
 rich==13.7.1
+setuptools==69.2.0
 six==1.16.0
 twine==5.0.0
 urllib3==2.2.1

--- a/build/pip/setup.tmpl
+++ b/build/pip/setup.tmpl
@@ -37,7 +37,7 @@ class CustomInstallCommand(install):
         _latest_version = json.loads(self._get(self._base_url).text)[0]['tag_name'].replace('v', '')
 
     def _get_gauge_file(self):
-        if self._os_name is 'win32':
+        if self._os_name == 'win32':
             return 'gauge.exe'
         else:
             return 'gauge'
@@ -63,7 +63,7 @@ class CustomInstallCommand(install):
             os.remove(target_path)
         if os.path.isfile(source_path):
             self.move_file(source_path, target_path)
-            if self._os_name is not "win32":
+            if self._os_name != "win32":
                 if sys.version_info[0] == 3:
                     os.chmod(target_path, 0o755)
                 if sys.version_info[0] < 3:


### PR DESCRIPTION
setuptools was removed by default in Python 3.12 but for now we need it, and I don't have the energy to convert this to a different mechanism right now :-)

Alternatively we can downgrade Python back to 3.11 or lower.