### PR TITLE
Correct NSIS downloads for Windows package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,7 @@ jobs:
         shell: powershell
         run: |
           Start-Sleep -Milliseconds 1
-          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-          Invoke-WebRequest "https://sourceforge.net/projects/nsis/files/NSIS%203/3.06.1/nsis-3.06.1-strlen_8192.zip/download" -UseBasicParsing -UserAgent [Microsoft.PowerShell.Commands.PSUserAgent]::Chrome -Outfile "./nsis.zip"
+          Invoke-WebRequest "https://sourceforge.net/projects/nsis/files/NSIS%203/3.10/nsis-3.10-strlen_8192.zip/download" -UserAgent "PowerShell" -Outfile "./nsis.zip"
           Expand-Archive -Force -LiteralPath ./nsis.zip -DestinationPath "C:\Program Files (x86)\NSIS\"
 
       - name: Compile gauge


### PR DESCRIPTION
Last release [didn't go through](https://github.com/getgauge/gauge/actions/runs/11028707276/job/30629634452); Sourceforge have changed the way their downloads work and the Chrome UserAgent is causing it to think there is a browser and use a cookie+javascript approach rather than normal redirects.

This also upgrades to latest NSIS (`3.10`)