### PR TITLE
fix: fix slice init length

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -125,7 +125,7 @@ func appendTags(s []string, tags *gauge.Tags) []string {
 
 func uniqueNonEmptyElementsOf(input []string) []string {
 	unique := make(map[string]bool, len(input))
-	us := make([]string, len(unique))
+	us := make([]string, 0, len(unique))
 	for _, elem := range input {
 		if len(elem) != 0 && !unique[elem] {
 			us = append(us, elem)


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of len(unique) rather than initializing the length of this slice. 

The only demo: https://go.dev/play/p/q1BcVCmvidW