### PR TITLE
Added logic adding/not adding empty lines when formatting specs based on flag/settings.

### DIFF
--- a/api/lang/server.go
+++ b/api/lang/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/getgauge/gauge/api/infoGatherer"
 	"github.com/getgauge/gauge/execution"
 	"github.com/getgauge/gauge/gauge"
+	"github.com/getgauge/gauge/config"
 	"github.com/sourcegraph/jsonrpc2"
 )
 
@@ -183,6 +184,17 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 			logDebug(req, err.Error())
 		}
 		return val, err
+	case "workspace/didChangeConfiguration":
+		err := config.UpdateSettings(req)
+		if err != nil {
+			logDebug(req, err.Error())
+			e := showErrorMessageOnClient(ctx, conn, err)
+			if e != nil {
+				return nil, fmt.Errorf("unable to send '%s' error to LSP server. %s", err.Error(), e.Error())
+			}
+		}
+		logDebug(req, "Updated settings.")
+		return nil, err
 	case "gauge/stepReferences":
 		val, err := stepReferences(req)
 		if err != nil {

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -12,6 +12,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var skipEmptyLineInsertions bool
+
 var formatCmd = &cobra.Command{
 	Use:     "format [flags] [args]",
 	Short:   "Formats the specified spec and/or concept files",
@@ -22,6 +24,7 @@ var formatCmd = &cobra.Command{
 			exit(err, cmd.UsageString())
 		}
 		loadEnvAndReinitLogger(cmd)
+		config.SetSkipEmptyLineInsertions(skipEmptyLineInsertions)
 		formatter.FormatSpecFilesIn(getSpecsDir(args)[0])
 		formatter.FormatConceptFilesIn(getSpecsDir(args)[0])
 	},
@@ -30,4 +33,5 @@ var formatCmd = &cobra.Command{
 
 func init() {
 	GaugeCmd.AddCommand(formatCmd)
+	formatCmd.Flags().BoolVarP(&skipEmptyLineInsertions, "skip-empty-line-insertions", "s", false, "Skip insertions of empty lines when formatting spec/concept files")
 }

--- a/config/settings.go
+++ b/config/settings.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"encoding/json"
+
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+var currentSettings GaugeSettings
+
+type FormatConfig struct {
+	SkipEmptyLineInsertions bool `json:"skipEmptyLineInsertions"`
+}
+
+type GaugeSettings struct {
+	Format FormatConfig `json:"formatting"`
+}
+
+type Settings struct {
+	Gauge GaugeSettings `json:"gauge"`
+}
+
+type DidChangeConfigurationParams struct {
+	Settings Settings `json:"settings"`
+}
+
+func UpdateSettings(request *jsonrpc2.Request) error {
+	var params DidChangeConfigurationParams
+	if err := json.Unmarshal(*request.Params, &params); err != nil {
+		return err
+	}
+	SetGaugeSettings(params.Settings.Gauge)
+	return nil
+}
+
+func SetGaugeSettings(gs GaugeSettings) {
+	currentSettings = gs
+}
+
+func CurrentGaugeSettings() GaugeSettings {
+	return currentSettings
+}
+
+func SetSkipEmptyLineInsertions(val bool) {
+	currentSettings.Format.SkipEmptyLineInsertions = val
+}

--- a/formatter/formatSpecification.go
+++ b/formatter/formatSpecification.go
@@ -11,6 +11,7 @@ import (
 
 	"strings"
 
+	"github.com/getgauge/gauge/config"
 	"github.com/getgauge/gauge/gauge"
 )
 
@@ -31,11 +32,11 @@ func (formatter *formatter) Heading(heading *gauge.Heading) {
 }
 
 func (formatter *formatter) Tags(tags *gauge.Tags) {
-	if !strings.HasSuffix(formatter.buffer.String(), "\n\n") {
+	if !strings.HasSuffix(formatter.buffer.String(), "\n\n") && !config.CurrentGaugeSettings().Format.SkipEmptyLineInsertions {
 		formatter.buffer.WriteString("\n")
 	}
 	formatter.buffer.WriteString(FormatTags(tags))
-	if formatter.itemQueue.Peek() != nil && (formatter.itemQueue.Peek().Kind() != gauge.CommentKind || strings.TrimSpace(formatter.itemQueue.Peek().(*gauge.Comment).Value) != "") {
+	if formatter.itemQueue.Peek() != nil && (formatter.itemQueue.Peek().Kind() != gauge.CommentKind || strings.TrimSpace(formatter.itemQueue.Peek().(*gauge.Comment).Value) != "") && !config.CurrentGaugeSettings().Format.SkipEmptyLineInsertions {
 		formatter.buffer.WriteString("\n")
 	}
 }

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -19,6 +19,7 @@ import (
 	"github.com/getgauge/gauge/logger"
 	"github.com/getgauge/gauge/parser"
 	"github.com/getgauge/gauge/util"
+	"github.com/getgauge/gauge/config"
 )
 
 const (
@@ -124,7 +125,9 @@ func FormatTable(table *gauge.Table) string {
 
 	var tableStringBuffer bytes.Buffer
 
+	if !config.CurrentGaugeSettings().Format.SkipEmptyLineInsertions {
 	tableStringBuffer.WriteString("\n")
+	}
 
 	tableStringBuffer.WriteString(fmt.Sprintf("%s|", getRepeatedChars(" ", tableLeftSpacing)))
 	for i, header := range table.Headers {

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 12}
+var CurrentGaugeVersion = &Version{1, 6, 13}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
1. Added a flag that makes it optional if you want the formatter to add empty lines around tags & before table definitions in the spec-files.
2. Implementation in server to handle requests from extension regarding changes in settings.json, where you can define the formatters behavior.
3. settings.go hold the 'state' of settings on the server-side, which can extended to hold any other settings added in the future.

To make it work fully a few lines needs to be in the VSC Extension as well, but I hold that until I know if this will be considered.

Further description in issue:
https://github.com/getgauge/gauge/issues/2693