### PR TITLE
Enabling formatting of .cpt files in IDE/VSC.

### DIFF
--- a/api/lang/format.go
+++ b/api/lang/format.go
@@ -38,6 +38,20 @@ func format(request *jsonrpc2.Request) (interface{}, error) {
 		oldString := getContent(params.TextDocument.URI)
 		textEdit := createTextEdit(newString, 0, 0, len(strings.Split(oldString, "\n")), len(oldString))
 		return []lsp.TextEdit{textEdit}, nil
+	} else if util.IsValidConceptExtension(file) {
+		conceptsDictionary := gauge.NewConceptDictionary()
+		_, parseErrs, err := parser.AddConcepts([]string{file}, conceptsDictionary)
+		if err != nil {
+			return nil, err
+		}
+		if parseErrs != nil {
+			return nil, fmt.Errorf("failed to format document. Fix all the problems first")
+		}
+		conceptMap := formatter.FormatConcepts(conceptsDictionary)
+		newString := conceptMap[file]
+		oldString := getContent(params.TextDocument.URI)
+		textEdit := createTextEdit(newString, 0, 0, len(strings.Split(oldString, "\n")), len(oldString))
+		return []lsp.TextEdit{textEdit}, nil
 	}
-	return nil, fmt.Errorf("failed to format document. %s is not a valid spec file", file)
+	return nil, fmt.Errorf("failed to format document. %s is not a valid spec/cpt file", file)
 }

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -15,11 +15,11 @@ import (
 
 	"github.com/getgauge/common"
 	"github.com/getgauge/gauge-proto/go/gauge_messages"
+	"github.com/getgauge/gauge/config"
 	"github.com/getgauge/gauge/gauge"
 	"github.com/getgauge/gauge/logger"
 	"github.com/getgauge/gauge/parser"
 	"github.com/getgauge/gauge/util"
-	"github.com/getgauge/gauge/config"
 )
 
 const (
@@ -71,7 +71,7 @@ func FormatStep(step *gauge.Step) string {
 		} else {
 			formattedArg = fmt.Sprintf("\"%s\"", parser.GetUnescapedString(argument.Value))
 		}
-		text = strings.Replace(text, stripBeforeArg + gauge.ParameterPlaceholder, formattedArg, 1)
+		text = strings.Replace(text, stripBeforeArg+gauge.ParameterPlaceholder, formattedArg, 1)
 	}
 	stepText := ""
 	if strings.HasSuffix(text, "\n") {
@@ -126,7 +126,7 @@ func FormatTable(table *gauge.Table) string {
 	var tableStringBuffer bytes.Buffer
 
 	if !config.CurrentGaugeSettings().Format.SkipEmptyLineInsertions {
-	tableStringBuffer.WriteString("\n")
+		tableStringBuffer.WriteString("\n")
 	}
 
 	tableStringBuffer.WriteString(fmt.Sprintf("%s|", getRepeatedChars(" ", tableLeftSpacing)))

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 13}
+var CurrentGaugeVersion = &Version{1, 6, 14}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
This PR: https://github.com/getgauge/gauge/pull/2566 implemeted the possiblity for format .cpt-files, but only from cmd, no binding via LSP was added. This adds it.
Originally related to: https://github.com/getgauge/gauge/issues/1509

@sriv Can you please merge?
