### PR TITLE
Don't compile with CGO for Windows

### DIFF
--- a/build/make.go
+++ b/build/make.go
@@ -36,7 +36,6 @@ const (
 	bin               = "bin"
 	gauge             = "gauge"
 	deploy            = "deploy"
-	CC                = "CC"
 	nightlyDatelayout = "2006-01-02"
 )
 
@@ -159,8 +158,8 @@ var (
 		{GOARCH: ARM64, GOOS: linux, CGO_ENABLED: "0"},
 		{GOARCH: X86, GOOS: freebsd, CGO_ENABLED: "0"},
 		{GOARCH: X86_64, GOOS: freebsd, CGO_ENABLED: "0"},
-		{GOARCH: X86, GOOS: windows, CC: "i586-mingw32-gcc", CGO_ENABLED: "1"},
-		{GOARCH: X86_64, GOOS: windows, CC: "x86_64-w64-mingw32-gcc", CGO_ENABLED: "1"},
+		{GOARCH: X86, GOOS: windows, CGO_ENABLED: "0"},
+		{GOARCH: X86_64, GOOS: windows, CGO_ENABLED: "0"},
 	}
 	osDistroMap = map[string]distroFunc{windows: createWindowsDistro, linux: createLinuxPackage, freebsd: createLinuxPackage, darwin: createDarwinPackage}
 )


### PR DESCRIPTION
CGO cross-compile was enabled in a8365f4ed7e63424f35f3c92dfe9d518555f6491 10 years ago, but without any comment as to why it was needed and no obvious commits around the same time - perhaps Windows native compilation was much less stable at the time (Golang `1.4` era)?

I'm not sure it is necessary anymore, so probably better to remove? WDYT @sriv?