### PR TITLE
Pad runner # display to 2 digits

### DIFF
--- a/logger/logWriter.go
+++ b/logger/logWriter.go
@@ -51,7 +51,7 @@ func (w Writer) Write(p []byte) (int, error) {
 			}
 		}
 		if w.stream > 0 {
-			m.Message = fmt.Sprintf("[runner: %d] %s", w.stream, m.Message)
+			m.Message = fmt.Sprintf("[runner: %2d] %s", w.stream, m.Message)
 		}
 		switch m.LogLevel {
 		case "debug":

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -90,7 +90,7 @@ type parallelReportWriter struct {
 }
 
 func (p *parallelReportWriter) Write(b []byte) (int, error) {
-	return fmt.Printf("[runner: %d] %s", p.nRunner, string(b))
+	return fmt.Printf("[runner: %2d] %s", p.nRunner, string(b))
 }
 
 // ParallelReporter returns the instance of parallel console reporter

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 16}
+var CurrentGaugeVersion = &Version{1, 6, 17}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
Many hosts have 10+ cores and default parallelisation is to # cores. Currently that causes misaligned output.

Have not made it "smart" enough to only pad when running with 10+ cores in total - not sure if this is needed?