### PR TITLE
Aggregate pre+post hook messages and screenshots from parallel tests

### DIFF
--- a/execution/parallelExecution.go
+++ b/execution/parallelExecution.go
@@ -295,9 +295,19 @@ func (e *parallelExecution) finish() {
 
 func (e *parallelExecution) aggregateResults(suiteResults []*result.SuiteResult) {
 	r := result.NewSuiteResult(ExecuteTags, e.startTime)
+	if e.suiteResult != nil {
+		r.PreHookMessages = e.suiteResult.PreHookMessages
+		r.PreHookScreenshotFiles = e.suiteResult.PreHookScreenshotFiles
+		r.PostHookMessages = e.suiteResult.PostHookMessages
+		r.PostHookScreenshotFiles = e.suiteResult.PostHookScreenshotFiles
+	}
 	for _, suiteResult := range suiteResults {
 		r.SpecsFailedCount += suiteResult.SpecsFailedCount
 		r.SpecResults = append(r.SpecResults, suiteResult.SpecResults...)
+		r.PreHookMessages = append(r.PreHookMessages, suiteResult.PreHookMessages...)
+		r.PreHookScreenshotFiles = append(r.PreHookScreenshotFiles, suiteResult.PreHookScreenshotFiles...)
+		r.PostHookMessages = append(r.PostHookMessages, suiteResult.PostHookMessages...)
+		r.PostHookScreenshotFiles = append(r.PostHookScreenshotFiles, suiteResult.PostHookScreenshotFiles...)
 		if suiteResult.IsFailed {
 			r.IsFailed = true
 		}

--- a/execution/parallelExecution_test.go
+++ b/execution/parallelExecution_test.go
@@ -49,9 +49,13 @@ func getValidationErrorMap() *gauge.BuildErrors {
 
 func (s *MySuite) TestAggregationOfSuiteResult(c *C) {
 	e := parallelExecution{errMaps: getValidationErrorMap()}
-	suiteRes1 := &result.SuiteResult{ExecutionTime: 1, SpecsFailedCount: 1, IsFailed: true, SpecResults: []*result.SpecResult{{}, {}}}
-	suiteRes2 := &result.SuiteResult{ExecutionTime: 3, SpecsFailedCount: 0, IsFailed: false, SpecResults: []*result.SpecResult{{}, {}}}
-	suiteRes3 := &result.SuiteResult{ExecutionTime: 5, SpecsFailedCount: 0, IsFailed: false, SpecResults: []*result.SpecResult{{}, {}}}
+
+	// Start with an initial result (e.g from multi-threaded execution)
+	e.suiteResult = &result.SuiteResult{ExecutionTime: 14, PreHookMessages: []string{"starting"}, PostHookMessages: []string{"stopping"}}
+
+	suiteRes1 := &result.SuiteResult{ExecutionTime: 1, SpecsFailedCount: 1, IsFailed: true, SpecResults: []*result.SpecResult{{}, {}}, PreHookMessages: []string{"Pre-1"}, PostHookMessages: []string{"Post-1"}}
+	suiteRes2 := &result.SuiteResult{ExecutionTime: 3, SpecsFailedCount: 0, IsFailed: false, SpecResults: []*result.SpecResult{{}, {}}, PreHookMessages: []string{"Pre-2"}, PostHookMessages: []string{"Post-2"}}
+	suiteRes3 := &result.SuiteResult{ExecutionTime: 5, SpecsFailedCount: 0, IsFailed: false, SpecResults: []*result.SpecResult{{}, {}}, PreHookMessages: []string{"Pre-3"}, PostHookMessages: []string{"Post-3"}}
 	var suiteResults []*result.SuiteResult
 	suiteResults = append(suiteResults, suiteRes1, suiteRes2, suiteRes3)
 	e.aggregateResults(suiteResults)
@@ -61,6 +65,8 @@ func (s *MySuite) TestAggregationOfSuiteResult(c *C) {
 	c.Assert(aggregatedRes.IsFailed, Equals, true)
 	c.Assert(len(aggregatedRes.SpecResults), Equals, 6)
 	c.Assert(aggregatedRes.SpecsSkippedCount, Equals, 0)
+	c.Assert(aggregatedRes.PreHookMessages, DeepEquals, []string{"starting", "Pre-1", "Pre-2", "Pre-3"})
+	c.Assert(aggregatedRes.PostHookMessages, DeepEquals, []string{"stopping", "Post-1", "Post-2", "Post-3"})
 }
 
 func (s *MySuite) TestAggregationOfSuiteResultWithUnhandledErrors(c *C) {

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 16}
+var CurrentGaugeVersion = &Version{1, 6, 17}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
Fixes #2747 
- should fix for both the "legacy" parallel and the multithreaded grpc case

Not really sure I know what I am doing here or what the consequences might be of this, but this does seem to work in both cases.

Would probably be better to have separate implementations for producing the final suiteResult between the two styles as the `aggregateResults` code path is clearly intended for the original legacy design.