### PR TITLE
chore: workaround broken setup-node action with NPM trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,8 @@ jobs:
           git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
 
       - name: Deploy npm
-        run: |
+        run: | # See https://github.com/actions/setup-node/issues/1440
+          unset NODE_AUTH_TOKEN
           cd build/npm
           npm version $GAUGE_VERSION
           npm publish --access=public

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 24}
+var CurrentGaugeVersion = &Version{1, 6, 25}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
Sigh. Follow-up to https://github.com/getgauge/gauge/pull/2818 which is broken due to https://github.com/actions/setup-node/issues/1440