### PR TITLE
Bump version to 1.6.31

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 30}
+var CurrentGaugeVersion = &Version{1, 6, 31}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
We see multiple vulnerabilities in packages installed from 1.26.2 go version

```
CVE-2026-33814 	 high 	 net/http 		 1.26.2 		 fixed in 1.25.10, 1.26.3
CVE-2026-39826 	 medium 	 html/template 		 1.26.2 		 fixed in 1.25.10, 1.26.3
CVE-2026-39823 	 medium 	 html/template 		 1.26.2 		 fixed in 1.25.10, 1.26.3
CVE-2026-33811 	 high 	 net 		 1.26.2 		 fixed in 1.25.10, 1.26.3
CVE-2026-39836 	 high 	 net 		 1.26.2 		 fixed in 1.25.10, 1.26.3
```

So I am hoping updating the gauge framework version will build the packages with the go version `1.26.3`