### PR TITLE
Start lang runner using abs path to mitigate Windows shell issues

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -96,6 +96,9 @@ func runRunnerCommand(manifest *manifest.Manifest, port string, debug bool, writ
 		return nil, nil, fmt.Errorf("Compatibility error. %s", compatibilityErr.Error())
 	}
 	command := getOsSpecificCommand(&r)
+	if len(command) > 0 && !filepath.IsAbs(command[0]) {
+		command[0] = filepath.Join(runnerDir, command[0])
+	}
 	env := getCleanEnv(port, os.Environ(), debug, getPluginPaths())
 	cmd, err := common.ExecuteCommandWithEnv(command, runnerDir, writer.Stdout, writer.Stderr, env)
 	return cmd, &r, err

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 31}
+var CurrentGaugeVersion = &Version{1, 6, 32}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
PR suggestion to mitigate issues with launching language runners on Windows where .cmd/.bat files are the entry point:
https://github.com/getgauge/gauge/issues/2855

A directory for the command was set in current implementation, but obviously not always honored on Windows. 

Therefore the suggestion is to point to the runners entry point using an absolute path instead. This of course requires that the language runner is designed so that works (i.e. entry point does not refer to some command expected to be in path). For the official runners, as far as I can see, this is not an issue.
