### PR TITLE
Add option to configure the maximum of log files to retain

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -25,6 +25,7 @@ const (
 	ideRequestTimeout       = "ide_request_timeout"
 	checkUpdates            = "check_updates"
 	allowInsecureDownload   = "allow_insecure_download"
+	logMaxBackups           = "log_max_backups"
 
 	defaultRunnerConnectionTimeout = time.Second * 25
 	defaultPluginConnectionTimeout = time.Second * 10
@@ -32,6 +33,7 @@ const (
 	defaultRefactorTimeout         = time.Second * 10
 	defaultRunnerRequestTimeout    = time.Second * 30
 	defaultIdeRequestTimeout       = time.Second * 30
+	defaultLogMaxBackups           = 3
 	LayoutForTimeStamp             = "Jan 2, 2006 at 3:04pm"
 )
 
@@ -91,6 +93,11 @@ func AllowInsecureDownload() bool {
 	return convertToBool(allow, allowInsecureDownload, false)
 }
 
+func LogMaxBackupsCount() int {
+	log_max_backups := getFromConfig(logMaxBackups)
+	return convertToInt(log_max_backups, logMaxBackups, defaultLogMaxBackups)
+}
+
 // GaugeRepositoryUrl fetches the repository URL to locate plugins
 func GaugeRepositoryUrl() string {
 	return getFromConfig(gaugeRepositoryURL)
@@ -133,6 +140,15 @@ func convertToBool(value, property string, defaultValue bool) bool {
 		return defaultValue
 	}
 	return boolValue
+}
+
+func convertToInt(value, property string, defaultValue int) int {
+	intValue, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil {
+		APILog.Warningf("Incorrect value for %s in property file. Cannot convert %s to integer.", property, value)
+		return defaultValue
+	}
+	return intValue
 }
 
 var getFromConfig = func(propertyName string) string {

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -25,7 +25,7 @@ const (
 	ideRequestTimeout       = "ide_request_timeout"
 	checkUpdates            = "check_updates"
 	allowInsecureDownload   = "allow_insecure_download"
-	logMaxBackups           = "log_max_backups"
+	logMaxBackupsCount      = "log_max_backups_count"
 
 	defaultRunnerConnectionTimeout = time.Second * 25
 	defaultPluginConnectionTimeout = time.Second * 10
@@ -33,7 +33,7 @@ const (
 	defaultRefactorTimeout         = time.Second * 10
 	defaultRunnerRequestTimeout    = time.Second * 30
 	defaultIdeRequestTimeout       = time.Second * 30
-	defaultLogMaxBackups           = 3
+	defaultLogMaxBackupsCount      = 3
 	LayoutForTimeStamp             = "Jan 2, 2006 at 3:04pm"
 )
 
@@ -94,8 +94,8 @@ func AllowInsecureDownload() bool {
 }
 
 func LogMaxBackupsCount() int {
-	log_max_backups := getFromConfig(logMaxBackups)
-	return convertToInt(log_max_backups, logMaxBackups, defaultLogMaxBackups)
+	log_max_backups_count := getFromConfig(logMaxBackupsCount)
+	return convertToInt(log_max_backups_count, logMaxBackupsCount, defaultLogMaxBackupsCount)
 }
 
 // GaugeRepositoryUrl fetches the repository URL to locate plugins

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -27,11 +27,11 @@ func stub4GetFromConfig(propertyName string) string {
 	return "true	"
 }
 
-func stubLogMaxBackupsDefault(propertyName string) string {
+func stubLogMaxBackupsCountDefault(propertyName string) string {
     return ""
 }
 
-func stubLogMaxBackupsCustom(propertyName string) string {
+func stubLogMaxBackupsCountCustom(propertyName string) string {
     return "10"
 }
 
@@ -81,15 +81,15 @@ func TestAllowUpdates(t *testing.T) {
 }
 
 func TestLogMaxBackups(t *testing.T) {
-	getFromConfig = stubLogMaxBackupsDefault
+	getFromConfig = stubLogMaxBackupsCountDefault
 	got := LogMaxBackupsCount()
 	if got != 3 {
-		t.Errorf("expected default MaxBackups to be 3, got %d", got)
+		t.Errorf("expected default LogMaxBackupsCount to be 3, got %d", got)
 	}
 
-	getFromConfig = stubLogMaxBackupsCustom
+	getFromConfig = stubLogMaxBackupsCountCustom
 	got = LogMaxBackupsCount()
 	if got != 10 {
-		t.Errorf("expected MaxBackups to be 10, got %d", got)
+		t.Errorf("expected LogMaxBackupsCount to be 10, got %d", got)
 	}
 }

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -27,6 +27,14 @@ func stub4GetFromConfig(propertyName string) string {
 	return "true	"
 }
 
+func stubLogMaxBackupsDefault(propertyName string) string {
+    return ""
+}
+
+func stubLogMaxBackupsCustom(propertyName string) string {
+    return "10"
+}
+
 func TestRunnerRequestTimeout(t *testing.T) {
 	getFromConfig = stubGetFromConfig
 	expected := defaultRunnerRequestTimeout
@@ -69,5 +77,19 @@ func TestAllowUpdates(t *testing.T) {
 	getFromConfig = stub4GetFromConfig
 	if !CheckUpdates() {
 		t.Error("Expected CheckUpdates=true, got false")
+	}
+}
+
+func TestLogMaxBackups(t *testing.T) {
+	getFromConfig = stubLogMaxBackupsDefault
+	got := LogMaxBackupsCount()
+	if got != 3 {
+		t.Errorf("expected default MaxBackups to be 3, got %d", got)
+	}
+
+	getFromConfig = stubLogMaxBackupsCustom
+	got = LogMaxBackupsCount()
+	if got != 10 {
+		t.Errorf("expected MaxBackups to be 10, got %d", got)
 	}
 }

--- a/config/formatter_test.go
+++ b/config/formatter_test.go
@@ -20,6 +20,7 @@ func TestJSONFormatter(t *testing.T) {
 		"check_updates                 	true                               ",
 		"gauge_repository_url          	https://downloads.gauge.org/plugin ",
 		"ide_request_timeout           	30000                              ",
+		"log_max_backups               	3                                  ",
 		"plugin_connection_timeout     	10000                              ",
 		"plugin_kill_timeout           	4000                               ",
 		"runner_connection_timeout     	30000                              ",

--- a/config/formatter_test.go
+++ b/config/formatter_test.go
@@ -20,7 +20,7 @@ func TestJSONFormatter(t *testing.T) {
 		"check_updates                 	true                               ",
 		"gauge_repository_url          	https://downloads.gauge.org/plugin ",
 		"ide_request_timeout           	30000                              ",
-		"log_max_backups               	3                                  ",
+		"log_max_backups_count         	3                                  ",
 		"plugin_connection_timeout     	10000                              ",
 		"plugin_kill_timeout           	4000                               ",
 		"runner_connection_timeout     	30000                              ",

--- a/config/properties.go
+++ b/config/properties.go
@@ -97,6 +97,7 @@ func defaults() *properties {
 		runnerRequestTimeout:    NewProperty(runnerRequestTimeout, "30000", "Timeout in milliseconds for requests from the language runner."),
 		ideRequestTimeout:       NewProperty(ideRequestTimeout, "30000", "Timeout in milliseconds for requests from runner when invoked for ide."),
 		checkUpdates:            NewProperty(checkUpdates, "true", "Allow Gauge and its plugin updates to be notified."),
+		logMaxBackups:           NewProperty(logMaxBackups, "3", "The maximum number of backup log files to retain."),
 	}}
 }
 

--- a/config/properties.go
+++ b/config/properties.go
@@ -97,7 +97,7 @@ func defaults() *properties {
 		runnerRequestTimeout:    NewProperty(runnerRequestTimeout, "30000", "Timeout in milliseconds for requests from the language runner."),
 		ideRequestTimeout:       NewProperty(ideRequestTimeout, "30000", "Timeout in milliseconds for requests from runner when invoked for ide."),
 		checkUpdates:            NewProperty(checkUpdates, "true", "Allow Gauge and its plugin updates to be notified."),
-		logMaxBackups:           NewProperty(logMaxBackups, "3", "The maximum number of backup log files to retain."),
+		logMaxBackupsCount:      NewProperty(logMaxBackupsCount, "3", "The maximum number of backup log files to retain."),
 	}}
 }
 

--- a/config/properties_test.go
+++ b/config/properties_test.go
@@ -117,7 +117,7 @@ gauge_repository_url = https://downloads.gauge.org/plugin
 ide_request_timeout = 30000
 
 # The maximum number of backup log files to retain.
-log_max_backups = 3
+log_max_backups_count = 3
 
 # Timeout in milliseconds for making a connection to plugins.
 plugin_connection_timeout = 10000

--- a/config/properties_test.go
+++ b/config/properties_test.go
@@ -116,6 +116,9 @@ gauge_repository_url = https://downloads.gauge.org/plugin
 # Timeout in milliseconds for requests from runner when invoked for ide.
 ide_request_timeout = 30000
 
+# The maximum number of backup log files to retain.
+log_max_backups = 3
+
 # Timeout in milliseconds for making a connection to plugins.
 plugin_connection_timeout = 10000
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -198,7 +198,7 @@ var createFileLogger = func(name string, size int) logging.Backend {
 	return logging.NewLogBackend(&lumberjack.Logger{
 		Filename:   name,
 		MaxSize:    size, // megabytes
-		MaxBackups: 3,
+		MaxBackups: config.LogMaxBackupsCount(),
 		MaxAge:     28, //days
 	}, "", 0)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 31}
+var CurrentGaugeVersion = &Version{1, 6, 32}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
Currently, the maximum number of gauge.log backup files is hardcoded to 3 in logger/logger.go. There is no way to change this without modifying and recompiling the source. In my code-base I need to have more log files as the project is huge and sometimes it is easier to see the point looking into the log files (and their timestamps).

This PR adds a new `log_max_backups` key to `gauge.properties`, allowing users to configure the number of backup log files to retain. The default value remains 3, so existing behaviour is unchanged.

Users can change the value via the existing gauge config CLI:

```bash
gauge config log_max_backups_count 10
```

Or: they rely on the well-known-default value of 3 without the need to change anything.