### PR TITLE
Fix issue to handle legacy projects without the new property 'log_max_backups_count' properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ build/pip/setup.py
 .eggs
 
 coverage.out
+*.log

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -93,8 +93,13 @@ func AllowInsecureDownload() bool {
 	return convertToBool(allow, allowInsecureDownload, false)
 }
 
+// The maximum number of backup log files to retain.
 func LogMaxBackupsCount() int {
 	log_max_backups_count := getFromConfig(logMaxBackupsCount)
+	if strings.TrimSpace(log_max_backups_count) == "" {
+		// Handle legacy projects without this config property
+		return defaultLogMaxBackupsCount
+	}
 	return convertToInt(log_max_backups_count, logMaxBackupsCount, defaultLogMaxBackupsCount)
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 32}
+var CurrentGaugeVersion = &Version{1, 6, 33}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
Unfortunately I missed one detail while testing the previous changes: my local config had the config at some point. While installing the new Gauge version in one of my containers, I realized, that it does not work as intendend.
 
I can see the following warning in the bash and also while installing it using the Windows installer:

```
2026/06/18 06:41:43 Incorrect value for log_max_backups_count in property file. Cannot convert  to integer.
```

This was visible using `gauge -v` too. With this PR I would like to resolve this issue.

What I have tested this time:

1. Local build, config has **no** property `log_max_backups_count`
2. Local build, config has a valid value for property `log_max_backups_count`
2. Local build, config has an **invalid** value for property `log_max_backups_count`: I can see the warning, which is good

Sorry for any inconveniences.

@zabil can you have another look please?