### PR TITLE
Fix for the parse error with back-to-back table tests in concept

### DIFF
--- a/parser/conceptParser.go
+++ b/parser/conceptParser.go
@@ -82,6 +82,7 @@ func (parser *ConceptParser) createConcepts(tokens []*Token, fileName string) ([
 			if errs := parser.processConceptStep(token, fileName); len(errs) > 0 {
 				finalResult.ParseErrors = append(finalResult.ParseErrors, errs...)
 			}
+			retainStates(&parser.currentState, conceptScope)
 			addStates(&parser.currentState, stepScope)
 		} else if parser.isTableHeader(token) {
 			if !isInState(parser.currentState, stepScope) {

--- a/parser/conceptParser_test.go
+++ b/parser/conceptParser_test.go
@@ -463,6 +463,56 @@ func (s *MySuite) TestParsingConceptStepWithInlineTable(c *C) {
 	c.Assert(nameCells[1].CellType, Equals, gauge.Static)
 }
 
+func (s *MySuite) TestParsingConceptWithConsecutiveInlineTablesWithoutBlankLine(c *C) {
+	parser := new(ConceptParser)
+	concepts, parseRes := parser.Parse("# my concept\n"+
+		"* step with table\n"+
+		" |id|name|\n"+
+		" |--|--|\n"+
+		" |1|one|\n"+
+		"* step with table\n"+
+		" |id|name|\n"+
+		" |--|--|\n"+
+		" |2|two|\n", "")
+
+	c.Assert(parseRes.Ok, Equals, true)
+	c.Assert(len(parseRes.ParseErrors), Equals, 0)
+	c.Assert(len(concepts), Equals, 1)
+
+	concept := concepts[0]
+
+	c.Assert(concept.IsConcept, Equals, true)
+	c.Assert(len(concept.ConceptSteps), Equals, 2)
+
+	tableArgument1 := concept.ConceptSteps[0].Args[0]
+	c.Assert(tableArgument1.ArgType, Equals, gauge.TableArg)
+
+	inlineTable1 := tableArgument1.Table
+	c.Assert(inlineTable1.IsInitialized(), Equals, true)
+	idCells1, _ := inlineTable1.Get("id")
+	nameCells1, _ := inlineTable1.Get("name")
+	c.Assert(len(idCells1), Equals, 1)
+	c.Assert(len(nameCells1), Equals, 1)
+	c.Assert(idCells1[0].Value, Equals, "1")
+	c.Assert(idCells1[0].CellType, Equals, gauge.Static)
+	c.Assert(nameCells1[0].Value, Equals, "one")
+	c.Assert(nameCells1[0].CellType, Equals, gauge.Static)
+
+	tableArgument2 := concept.ConceptSteps[1].Args[0]
+	c.Assert(tableArgument2.ArgType, Equals, gauge.TableArg)
+
+	inlineTable2 := tableArgument2.Table
+	c.Assert(inlineTable2.IsInitialized(), Equals, true)
+	idCells2, _ := inlineTable2.Get("id")
+	nameCells2, _ := inlineTable2.Get("name")
+	c.Assert(len(idCells2), Equals, 1)
+	c.Assert(len(nameCells2), Equals, 1)
+	c.Assert(idCells2[0].Value, Equals, "2")
+	c.Assert(idCells2[0].CellType, Equals, gauge.Static)
+	c.Assert(nameCells2[0].Value, Equals, "two")
+	c.Assert(nameCells2[0].CellType, Equals, gauge.Static)
+}
+
 func (s *MySuite) TestErrorParsingConceptWithInvalidInlineTable(c *C) {
 	parser := new(ConceptParser)
 	_, parseRes := parser.Parse("# my concept \n |id|name|\n|1|vishnu|\n|2|prateek|\n", "")

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 31}
+var CurrentGaugeVersion = &Version{1, 6, 32}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 33}
+var CurrentGaugeVersion = &Version{1, 6, 34}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
# Problem

When a concept definition contains two consecutive steps that each have an inline table (with no blank line between them), the second table's separator row (|--|--|) is incorrectly treated as a data row and appended to the first step's table.

This is been around for a long time (always?): https://github.com/getgauge/gauge/issues/1420

For example:

```
  # my concept
  * step with table
   |id|name|
   |--|----|
   |1 |one |
  * step with table
   |id|name|
   |--|----|       <-- treated as data row, not a separator
   |2 |two |
```

# Why?

The ConceptParser uses a bitmask-based state machine to track the current parsing context. When a table data row is encountered, the parser checks:

```
  if areUnderlined(token.Args) && !isInState(parser.currentState, tableSeparatorScope) {
      addStates(&parser.currentState, tableSeparatorScope)
  } else if isInState(parser.currentState, stepScope) {
      parser.processTableDataRow(token, &parser.currentConcept.Lookup, fileName)
  }
```

The first table's separator sets tableSeparatorScope in the state. When a new step token was encountered, the parser only called addStates(&parser.currentState, stepScope) without clearing the previous state. This meant tableSeparatorScope persisted from the first step into the second.

When the second table's separator `|--|--|` arrives, areUnderlined returns true but `!isInState(parser.currentState, tableSeparatorScope)` is false because it's still set from the first table. So the first branch is skipped, and the else if branch treats it as a regular data row, calling `processTableDataRow` which appends `--|--` as data to the current step's table.

# Fix

Added `retainStates(&parser.currentState, conceptScope)` before `addStates(&parser.currentState, stepScope)` when processing a new step token. retainStates performs a bitmask AND, keeping only the specified scopes and clearing everything else, including the stale tableSeparatorScope (and tableScope) left over from the previous step's inline table. This allows the second table's separator to be correctly recognized.

This is consistent with how state transitions are already handled elsewhere in the parser for example, the comment token handler at line 104 uses the same retainStates(&parser.currentState, conceptScope) pattern.

# Test

* Added `TestParsingConceptWithConsecutiveInlineTablesWithoutBlankLine` which parses a concept with two steps each having an inline table (no blank line separator) and verifies:
  - Parse succeeds with no errors
  - The concept contains exactly 2 steps
  - Each step has its own initialized inline table with the correct columns, row count, cell values, and cell types
* Verified the test fails before the fix and passes after