### PR TITLE
Bump version to 1.6.34

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 33}
+var CurrentGaugeVersion = &Version{1, 6, 34}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
Update Gauge version from 1.6.33 to 1.6.34 to address CVE-2026-42505 in crypto/tls package. Hoping that The new release will be built with Go 1.26.5 which includes the security fix.



```
Vulnerability addressed:

CVE-2026-42505 (Medium severity, CVSS 5.3)
Package: crypto/tls
Current version: 1.26.4
Fixed in: Go 1.26.5, 1.27.0-rc.2
```