### PR TITLE
fix: correct inflated failed-count for scenario-datatable scenarios

### DIFF
--- a/execution/result/specResult.go
+++ b/execution/result/specResult.go
@@ -52,7 +52,9 @@ func (specResult *SpecResult) AddScenarioResults(scenarioResults []Result) {
 func (specResult *SpecResult) AddTableDrivenScenarioResult(r *ScenarioResult, t *gauge_messages.ProtoTable, scenarioRowIndex int, specRowIndex int, specTableDriven bool) {
 	if r.GetFailed() {
 		specResult.IsFailed = true
-		specResult.ScenarioFailedCount++
+		// ScenarioFailedCount is aggregated once per distinct scenario by the
+		// caller (executeScenarioTableDrivenScenarios), not per data-table row,
+		// so that passed = executed - failed stays consistent with ScenarioCount.
 	}
 	specResult.AddExecTime(r.ExecTime())
 	pItem := &gauge_messages.ProtoItem{ // nolint

--- a/execution/result/specResult_test.go
+++ b/execution/result/specResult_test.go
@@ -69,3 +69,32 @@ func (s *MySuite) TestAddTableRelatedScenarioResult(c *gc.C) {
 	c.Assert(specResult.ScenarioFailedCount, gc.Equals, 0)
 	c.Assert(specResult.ExecutionTime, gc.Equals, int64(0))
 }
+
+// A scenario that owns a scenario-level data table runs once per row. The
+// caller (executeScenarioTableDrivenScenarios) is responsible for counting the
+// scenario as failed at most once, so AddTableDrivenScenarioResult must not bump
+// ScenarioFailedCount per row - otherwise passed = executed - failed goes
+// negative and passing scenarios vanish from the summary (issue #1802).
+func (s *MySuite) TestAddTableDrivenScenarioResultDoesNotBumpFailedCountPerRow(c *gc.C) {
+	specResult := SpecResult{
+		ProtoSpec: &gauge_messages.ProtoSpec{Items: []*gauge_messages.ProtoItem{}},
+	}
+	heading := "Scenario heading"
+	table := &gauge_messages.ProtoTable{}
+
+	// Two failing rows of the same scenario-data-table scenario.
+	for rowIndex := 0; rowIndex < 2; rowIndex++ {
+		failedScenario := &gauge_messages.ProtoScenario{
+			ScenarioHeading: heading,
+			ExecutionStatus: gauge_messages.ExecutionStatus_FAILED,
+		}
+		r := NewScenarioResult(failedScenario)
+		specResult.AddTableDrivenScenarioResult(r, table, rowIndex, 0, false)
+	}
+
+	// The spec is marked failed, but the per-row failed count is NOT incremented
+	// here - aggregation is owned by executeScenarioTableDrivenScenarios.
+	c.Assert(specResult.GetFailed(), gc.Equals, true)
+	c.Assert(specResult.ScenarioFailedCount, gc.Equals, 0)
+	c.Assert(len(specResult.ProtoSpec.Items), gc.Equals, 2)
+}

--- a/execution/specExecutor.go
+++ b/execution/specExecutor.go
@@ -160,6 +160,7 @@ func (e *specExecutor) executeSpec() error {
 
 func (e *specExecutor) executeScenarioTableDrivenScenarios(scenarios []*gauge.Scenario) {
 	scnMap := make(map[int]bool)
+	failedScnMap := make(map[int]bool)
 	for _, s := range scenarios {
 		if _, ok := scnMap[s.Span.Start]; !ok {
 			scnMap[s.Span.Start] = true
@@ -168,10 +169,14 @@ func (e *specExecutor) executeScenarioTableDrivenScenarios(scenarios []*gauge.Sc
 		if err != nil {
 			logger.Fatalf(true, "Failed to resolve Specifications : %s", err.Error())
 		}
+		if r.GetFailed() {
+			failedScnMap[s.Span.Start] = true
+		}
 		e.specResult.AddTableDrivenScenarioResult(r, gauge.ConvertToProtoTable(s.DataTable.Table),
 			s.ScenarioDataTableRowIndex, s.SpecDataTableRowIndex, s.SpecDataTableRow.IsInitialized())
 	}
 	e.specResult.ScenarioCount += len(scnMap)
+	e.specResult.ScenarioFailedCount += len(failedScnMap)
 }
 
 func (e *specExecutor) initSpecDataStore() *gauge_messages.ProtoExecutionResult {


### PR DESCRIPTION
## Summary

Fixes the inflated failed-scenario count for scenarios that own a scenario-level
data table (`allow_scenario_datatable = true`), which caused passing scenarios to
be omitted from the final summary (#1802, confirmed reproducible by @NivedhaSenthil).

The final summary computes `passed = executed - failed`
(`execution/execute.go`). For a scenario that owns a scenario data table, the two
counters were incremented inconsistently:

- `ScenarioCount` is deduped per scenario: `executeScenarioTableDrivenScenarios`
  adds `len(scnMap)` (keyed on `s.Span.Start`), so a 5-row scenario adds **1**.
- `ScenarioFailedCount` was incremented **per row** inside
  `AddTableDrivenScenarioResult`, so a single failing 5-row scenario added **5**.

For the issue's repro spec (3 scenarios, the middle one a 5-row all-failing
scenario data table) this gave `executed = 3`, `failed = 5`, so
`passed = 3 - 5 = -2`, clamped to `0`. The two genuinely passing scenarios
vanished and the failed column read 5 instead of 1.

## Why this matters

The summary is the primary signal a user reads after a run. A negative
(clamped-to-zero) passed count silently hides real passing scenarios and reports
a failure total that does not match the number of scenarios, which is misleading
and erodes trust in the report.

## Fix

Make the failed count deduped per scenario, mirroring the already-correct
`ScenarioCount` add and the spec-data-table path in
`AddTableRelatedScenarioResult`:

- `execution/result/specResult.go`: `AddTableDrivenScenarioResult` no longer
  increments `ScenarioFailedCount` per row; it still sets `IsFailed = true` so
  the spec is marked failed.
- `execution/specExecutor.go`: `executeScenarioTableDrivenScenarios` tracks
  distinct failing scenarios (by `Span.Start`) and adds that deduped count to
  `ScenarioFailedCount` after the loop, parallel to `ScenarioCount += len(scnMap)`.

After the fix the repro spec yields `executed = 3`, `failed = 1`, `passed = 2` —
`Scenarios: 3 executed 2 passed 1 failed 0 skipped`.

The spec-data-table merge path (`mergeResults` / `aggregateDataTableScnStats`,
which recompute counts from proto items) is untouched, so there is no regression
for specs that also have a spec-level data table.

## Testing

Added `TestAddTableDrivenScenarioResultDoesNotBumpFailedCountPerRow` in
`execution/result/specResult_test.go`: two failing rows of one scenario-data-table
scenario leave `ScenarioFailedCount == 0` at the `AddTableDrivenScenarioResult`
level while still setting the spec failed, proving aggregation is owned by the
caller. `go build ./...`, `go vet ./execution/...`, and `go test ./execution/...`
all pass.

Closes #1802
