### PR TITLE
Add option to decide on execution strategy when using data tables

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -26,6 +26,7 @@ const (
 	checkUpdates            = "check_updates"
 	allowInsecureDownload   = "allow_insecure_download"
 	logMaxBackupsCount      = "log_max_backups_count"
+	dataTableMode           = "data_table_mode"
 
 	defaultRunnerConnectionTimeout = time.Second * 25
 	defaultPluginConnectionTimeout = time.Second * 10
@@ -34,6 +35,7 @@ const (
 	defaultRunnerRequestTimeout    = time.Second * 30
 	defaultIdeRequestTimeout       = time.Second * 30
 	defaultLogMaxBackupsCount      = 3
+	defaultDataTableMode           = "filter"
 	LayoutForTimeStamp             = "Jan 2, 2006 at 3:04pm"
 )
 
@@ -101,6 +103,21 @@ func LogMaxBackupsCount() int {
 		return defaultLogMaxBackupsCount
 	}
 	return convertToInt(log_max_backups_count, logMaxBackupsCount, defaultLogMaxBackupsCount)
+}
+
+func DataTableMode() string {
+	mode := getFromConfig(dataTableMode)
+	switch mode {
+	case "matrix":
+		return "matrix"
+	case "filter":
+		return "filter"
+	default:
+		if mode != "" && mode != defaultDataTableMode {
+			APILog.Warningf("Unknown value for %s: '%s'. Falling back to '%s'.", dataTableMode, mode, defaultDataTableMode)
+		}
+		return defaultDataTableMode
+	}
 }
 
 // GaugeRepositoryUrl fetches the repository URL to locate plugins

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -11,29 +11,18 @@ import (
 	"testing"
 )
 
-func stubGetFromConfig(propertyName string) string {
-	return ""
-}
+func stubGetFromConfig(propertyName string) string { return "" }
+func stub2GetFromConfig(propertyName string) string { return "10000" }
+func stub3GetFromConfig(propertyName string) string { return "false" }
+func stub4GetFromConfig(propertyName string) string { return "true	" }
 
-func stub2GetFromConfig(propertyName string) string {
-	return "10000"
-}
+func stubLogMaxBackupsCountDefault(propertyName string) string { return "" }
+func stubLogMaxBackupsCountCustom(propertyName string) string { return "10" }
 
-func stub3GetFromConfig(propertyName string) string {
-	return "false"
-}
+func stubDataTableModeFilter(propertyName string) string { return "filter" }
+func stubDataTableModeMatrix(propertyName string) string { return "matrix" }
+func stubDataTableModeInvalid(propertyName string) string { return "banana" }
 
-func stub4GetFromConfig(propertyName string) string {
-	return "true	"
-}
-
-func stubLogMaxBackupsCountDefault(propertyName string) string {
-    return ""
-}
-
-func stubLogMaxBackupsCountCustom(propertyName string) string {
-    return "10"
-}
 
 func TestRunnerRequestTimeout(t *testing.T) {
 	getFromConfig = stubGetFromConfig
@@ -91,5 +80,27 @@ func TestLogMaxBackups(t *testing.T) {
 	got = LogMaxBackupsCount()
 	if got != 10 {
 		t.Errorf("expected LogMaxBackupsCount to be 10, got %d", got)
+	}
+}
+
+func TestDataTableMode(t *testing.T) {
+	getFromConfig = stubGetFromConfig
+	if DataTableMode() != "filter" {
+		t.Errorf("expected default to be 'filter'")
+	}
+
+	getFromConfig = stubDataTableModeFilter
+	if DataTableMode() != "filter" {
+		t.Errorf("expected 'filter'")
+	}
+
+	getFromConfig = stubDataTableModeMatrix
+	if DataTableMode() != "matrix" {
+		t.Errorf("expected 'matrix'")
+	}
+
+	getFromConfig = stubDataTableModeInvalid
+	if DataTableMode() != "filter" {
+		t.Errorf("expected fallback to 'filter' on invalid value")
 	}
 }

--- a/config/formatter_test.go
+++ b/config/formatter_test.go
@@ -18,6 +18,7 @@ func TestJSONFormatter(t *testing.T) {
 		"Key                           	Value                              ",
 		"allow_insecure_download       	false                              ",
 		"check_updates                 	true                               ",
+		"data_table_mode               	filter                             ",
 		"gauge_repository_url          	https://downloads.gauge.org/plugin ",
 		"ide_request_timeout           	30000                              ",
 		"log_max_backups_count         	3                                  ",

--- a/config/properties.go
+++ b/config/properties.go
@@ -98,6 +98,7 @@ func defaults() *properties {
 		ideRequestTimeout:       NewProperty(ideRequestTimeout, "30000", "Timeout in milliseconds for requests from runner when invoked for ide."),
 		checkUpdates:            NewProperty(checkUpdates, "true", "Allow Gauge and its plugin updates to be notified."),
 		logMaxBackupsCount:      NewProperty(logMaxBackupsCount, "3", "The maximum number of backup log files to retain."),
+		dataTableMode:           NewProperty(dataTableMode, "filter", "How data table rows are applied to scenarios. Use 'filter' to execute scenarios without using the data table once, or 'matrix' to run all scenarios against all data table rows."),
 	}}
 }
 

--- a/config/properties_test.go
+++ b/config/properties_test.go
@@ -110,6 +110,9 @@ allow_insecure_download = false
 # Allow Gauge and its plugin updates to be notified.
 check_updates = true
 
+# How data table rows are applied to scenarios. Use 'filter' to execute scenarios without using the data table once, or 'matrix' to run all scenarios against all data table rows.
+data_table_mode = filter
+
 # Url to get plugin versions
 gauge_repository_url = https://downloads.gauge.org/plugin
 

--- a/parser/dataTableSpecs.go
+++ b/parser/dataTableSpecs.go
@@ -12,12 +12,16 @@ import (
 )
 
 // GetSpecsForDataTableRows creates a spec for each data table row
-func GetSpecsForDataTableRows(s []*gauge.Specification, errMap *gauge.BuildErrors) (specs []*gauge.Specification) {
+func GetSpecsForDataTableRows(s []*gauge.Specification, data_table_mode string, errMap *gauge.BuildErrors) (specs []*gauge.Specification) {
 	for _, spec := range s {
 		if spec.DataTable.IsInitialized() {
 			if spec.UsesArgsInContextTeardown(spec.DataTable.Table.Headers...) {
 				specs = append(specs, createSpecsForTableRows(spec, spec.Scenarios, errMap)...)
+			} else if data_table_mode == "matrix" {
+				// all scenarios run against all data table rows
+				specs = append(specs, createSpecsForTableRows(spec, spec.Scenarios, errMap)...)
 			} else {
+				// scenarios without accessing the data table, are executed once
 				nonTableRelatedScenarios, tableRelatedScenarios := FilterTableRelatedScenarios(spec.Scenarios, func(scenario *gauge.Scenario) bool {
 					return scenario.UsesArgsInSteps(spec.DataTable.Table.Headers...)
 				})

--- a/parser/dataTableSpecs_test.go
+++ b/parser/dataTableSpecs_test.go
@@ -94,7 +94,7 @@ var tests = []DataTableSpecTest{
 
 func TestGetSpecsForDataTableRows(t *testing.T) {
 	for _, test := range tests {
-		got := GetSpecsForDataTableRows(test.specs, gauge.NewBuildErrors())
+		got := GetSpecsForDataTableRows(test.specs, "filter", gauge.NewBuildErrors())
 
 		if len(got) != test.want {
 			t.Errorf("Failed: %s. Wanted: %d specs, Got: %d specs", test.message, test.want, len(got))
@@ -115,7 +115,7 @@ func TestGetSpecsForDataTableRowsShouldHaveEqualNumberOfScenearioInSpecsScenario
 			}, 0)},
 		},
 	}
-	actualSpecs := GetSpecsForDataTableRows(specs, gauge.NewBuildErrors())
+	actualSpecs := GetSpecsForDataTableRows(specs, "filter", gauge.NewBuildErrors())
 	if !containsScenario(actualSpecs[0].Scenarios, actualSpecs[0].Items) {
 		itemsJSON, _ := json.Marshal(actualSpecs[0].Items)
 		scnJSON, _ := json.Marshal(actualSpecs[0].Scenarios)
@@ -151,7 +151,7 @@ func TestGetSpecsForDataTableRowsShouldHaveEqualNumberOfScenearioInSpecsScenario
 			},
 		},
 	}
-	actualSpecs := GetSpecsForDataTableRows(specs, gauge.NewBuildErrors())
+	actualSpecs := GetSpecsForDataTableRows(specs, "filter", gauge.NewBuildErrors())
 
 	if !containsScenario(actualSpecs[0].Scenarios, actualSpecs[0].Items) {
 		itemsJSON, _ := json.Marshal(actualSpecs[0].Items)
@@ -184,7 +184,7 @@ func TestGetSpecsForDataTableRowsWithMixedScenarios(t *testing.T) {
 		},
 	}
 
-	actualSpecs := GetSpecsForDataTableRows(specs, gauge.NewBuildErrors())
+	actualSpecs := GetSpecsForDataTableRows(specs, "filter", gauge.NewBuildErrors())
 
 	if len(actualSpecs) != 2 {
 		t.Errorf("Expected 2 specs (one per spec table row), got %d", len(actualSpecs))

--- a/validation/validate.go
+++ b/validation/validate.go
@@ -24,6 +24,7 @@ import (
 
 	gm "github.com/getgauge/gauge-proto/go/gauge_messages"
 	"github.com/getgauge/gauge/api"
+	"github.com/getgauge/gauge/config"
 	"github.com/getgauge/gauge/gauge"
 	"github.com/getgauge/gauge/logger"
 	"github.com/getgauge/gauge/parser"
@@ -173,7 +174,7 @@ func ValidateSpecs(specsToValidate []string, debug bool) *ValidationResult {
 	r := startAPI(debug)
 	validationErrors := NewValidator(specs, r, conceptDict).Validate()
 	errMap = getErrMap(errMap, validationErrors)
-	specs = parser.GetSpecsForDataTableRows(specs, errMap)
+	specs = parser.GetSpecsForDataTableRows(specs, config.DataTableMode(), errMap)
 	printValidationFailures(validationErrors)
 	showSuggestion(validationErrors)
 	if !res.Ok {

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CurrentGaugeVersion represents the current version of Gauge
-var CurrentGaugeVersion = &Version{1, 6, 35}
+var CurrentGaugeVersion = &Version{1, 6, 36}
 
 // BuildMetadata represents build information of current release (e.g, nightly build information)
 var BuildMetadata = ""


### PR DESCRIPTION
This PR is about to resolve the topic described in https://github.com/getgauge/html-report/issues/388 

You can decide which strategy to use:
1. filter (default): keep everything as it is, scenarios without accessing the data table, are executed once
2. matrix: every scenario of the spec will be executed regardless if the data table is accessed or not

You can configure Gauge with:

```
gauge config data_table_mode <OPTION>
```

I tested it locally, both options, and it is like expected: 4 scenarios by default, 6 scenarios using the new option "matrix". The numbers are explained in the mentioned issue.