### PR TITLE
Adding unique keys for keeping track of scenarios in rerun report.

### DIFF
--- a/execution/rerun/rerun.go
+++ b/execution/rerun/rerun.go
@@ -46,7 +46,7 @@ type failureKey struct {
 
 func newScenarioFailureKey(filePath string, sce *gauge.Scenario) failureKey {
 	k := failureKey{filePath: filePath, line: sce.Span.Start}
-	if sce.SpecDataTableRow.IsInitialized() || sce.ScenarioDataTableRow.IsInitialized() {
+	if sce.HasSpecDataTable {
 		k.hasSpecDataTableRow = true
 		k.specDataTableRow = sce.SpecDataTableRowIndex
 	}

--- a/execution/rerun/rerun.go
+++ b/execution/rerun/rerun.go
@@ -12,14 +12,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strings"
 	"sync"
 
 	"github.com/getgauge/common"
 	"github.com/getgauge/gauge-proto/go/gauge_messages"
 	"github.com/getgauge/gauge/config"
-	"github.com/getgauge/gauge/env"
 	"github.com/getgauge/gauge/execution/event"
 	"github.com/getgauge/gauge/execution/result"
 	"github.com/getgauge/gauge/gauge"
@@ -38,9 +35,38 @@ func init() {
 	failedMeta = newFailedMetaData()
 }
 
+type failureKey struct {
+	filePath                string
+	line                    int
+	specDataTableRow        int
+	scenarioDataTableRow    int
+	hasSpecDataTableRow     bool
+	hasScenarioDataTableRow bool
+}
+
+func newScenarioFailureKey(filePath string, sce *gauge.Scenario) failureKey {
+	k := failureKey{filePath: filePath, line: sce.Span.Start}
+	if sce.SpecDataTableRow.IsInitialized() || sce.ScenarioDataTableRow.IsInitialized() {
+		k.hasSpecDataTableRow = true
+		k.specDataTableRow = sce.SpecDataTableRowIndex
+	}
+	if sce.ScenarioDataTableRow.IsInitialized() {
+		k.hasScenarioDataTableRow = true
+		k.scenarioDataTableRow = sce.ScenarioDataTableRowIndex
+	}
+	return k
+}
+
+func (k failureKey) outputRef() string {
+	if k.line == 0 {
+		return k.filePath
+	}
+	return fmt.Sprintf("%s:%d", k.filePath, k.line)
+}
+
 type failedMetadata struct {
 	Args           []string
-	failedItemsMap map[string]map[string]bool
+	failedItemsMap map[string]map[failureKey]bool
 	FailedItems    []string
 }
 
@@ -53,12 +79,12 @@ func (m *failedMetadata) getFailedItems() []string {
 	failedItems := []string{}
 	for _, v := range m.failedItemsMap {
 		for k := range v {
-			outputRef := scenarioFailureRefForOutput(k)
-			if seen[outputRef] {
+			ref := k.outputRef()
+			if seen[ref] {
 				continue
 			}
-			seen[outputRef] = true
-			failedItems = append(failedItems, outputRef)
+			seen[ref] = true
+			failedItems = append(failedItems, ref)
 		}
 	}
 	return failedItems
@@ -69,17 +95,17 @@ func (m *failedMetadata) aggregateFailedItems() {
 }
 
 func newFailedMetaData() *failedMetadata {
-	return &failedMetadata{Args: make([]string, 0), failedItemsMap: make(map[string]map[string]bool), FailedItems: []string{}}
+	return &failedMetadata{Args: make([]string, 0), failedItemsMap: make(map[string]map[failureKey]bool), FailedItems: []string{}}
 }
 
-func (m *failedMetadata) addFailedItem(itemName string, item string) {
+func (m *failedMetadata) addFailedItem(itemName string, item failureKey) {
 	if _, ok := m.failedItemsMap[itemName]; !ok {
-		m.failedItemsMap[itemName] = make(map[string]bool)
+		m.failedItemsMap[itemName] = make(map[failureKey]bool)
 	}
 	m.failedItemsMap[itemName][item] = true
 }
 
-func (m *failedMetadata) removeFailedItem(itemName string, item string) {
+func (m *failedMetadata) removeFailedItem(itemName string, item failureKey) {
 	if _, ok := m.failedItemsMap[itemName]; !ok {
 		return
 	}
@@ -115,57 +141,32 @@ func ListenFailedScenarios(wg *sync.WaitGroup, specDirs []string) {
 	}()
 }
 
-func scenarioFailureRef(failedScenario string, sce *gauge.Scenario) string {
-	ref := fmt.Sprintf("%s:%d", failedScenario, sce.Span.Start)
-	if sce.SpecDataTableRow.IsInitialized() || sce.ScenarioDataTableRow.IsInitialized() {
-		ref += fmt.Sprintf(":%d", sce.SpecDataTableRowIndex)
-	}
-	if sce.ScenarioDataTableRow.IsInitialized() {
-		ref += fmt.Sprintf(":%d", sce.ScenarioDataTableRowIndex)
-	}
-	return ref
-}
-
-func scenarioFailureRefForOutput(ref string) string {
-	exts := env.GaugeSpecFileExtensions()
-	escaped := make([]string, len(exts))
-	for i, ext := range exts {
-		escaped[i] = regexp.QuoteMeta(ext)
-	}
-	pattern := fmt.Sprintf(`(?i)^(.+(?:%s)):(\d+)`, strings.Join(escaped, "|"))
-	re := regexp.MustCompile(pattern)
-	if matches := re.FindStringSubmatch(ref); len(matches) == 3 {
-		return fmt.Sprintf("%s:%s", matches[1], matches[2])
-	}
-	return ref
-}
-
 func prepareScenarioFailedMetadata(res *result.ScenarioResult, sce *gauge.Scenario, executionInfo *gauge_messages.ExecutionInfo) {
 	specPath := executionInfo.GetCurrentSpec().GetFileName()
 	failedScenario := util.RelPathToProjectRoot(specPath)
-	scenarioRef := scenarioFailureRef(failedScenario, sce)
+	key := newScenarioFailureKey(failedScenario, sce)
 	if res.GetFailed() {
-		failedMeta.addFailedItem(specPath, scenarioRef)
+		failedMeta.addFailedItem(specPath, key)
 		return
 	}
 	// A scenario can emit multiple ScenarioEnd events when retries are enabled.
 	// If a later retry passes, remove any failed entry captured from earlier attempts.
-	failedMeta.removeFailedItem(specPath, scenarioRef)
+	failedMeta.removeFailedItem(specPath, key)
 }
 
 func addSpecFailedMetadata(res result.Result, args []string) {
 	fileName := util.RelPathToProjectRoot(res.(*result.SpecResult).ProtoSpec.GetFileName())
 	delete(failedMeta.failedItemsMap, fileName)
-	failedMeta.addFailedItem(fileName, fileName)
+	failedMeta.addFailedItem(fileName, failureKey{filePath: fileName})
 }
 
 func addSuiteFailedMetadata(res result.Result, args []string) {
-	failedMeta.failedItemsMap = make(map[string]map[string]bool)
+	failedMeta.failedItemsMap = make(map[string]map[failureKey]bool)
 	for _, arg := range args {
 		path, err := filepath.Abs(arg)
 		path = util.RelPathToProjectRoot(path)
 		if err == nil {
-			failedMeta.addFailedItem(path, path)
+			failedMeta.addFailedItem(path, failureKey{filePath: path})
 		}
 	}
 }

--- a/execution/rerun/rerun.go
+++ b/execution/rerun/rerun.go
@@ -13,11 +13,13 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/getgauge/common"
 	"github.com/getgauge/gauge-proto/go/gauge_messages"
 	"github.com/getgauge/gauge/config"
+	"github.com/getgauge/gauge/env"
 	"github.com/getgauge/gauge/execution/event"
 	"github.com/getgauge/gauge/execution/result"
 	"github.com/getgauge/gauge/gauge"
@@ -29,8 +31,6 @@ const (
 	failedFile         = "failures.json"
 	lastRunCmdFileName = "lastRunCmd.json"
 )
-
-var scenarioFailureRefPattern = regexp.MustCompile(`(?i)^(.+\.(?:spec|md)):(\d+)`)
 
 var failedMeta *failedMetadata
 
@@ -117,7 +117,7 @@ func ListenFailedScenarios(wg *sync.WaitGroup, specDirs []string) {
 
 func scenarioFailureRef(failedScenario string, sce *gauge.Scenario) string {
 	ref := fmt.Sprintf("%s:%d", failedScenario, sce.Span.Start)
-	if sce.SpecDataTableRow.IsInitialized() {
+	if sce.SpecDataTableRow.IsInitialized() || sce.ScenarioDataTableRow.IsInitialized() {
 		ref += fmt.Sprintf(":%d", sce.SpecDataTableRowIndex)
 	}
 	if sce.ScenarioDataTableRow.IsInitialized() {
@@ -127,7 +127,14 @@ func scenarioFailureRef(failedScenario string, sce *gauge.Scenario) string {
 }
 
 func scenarioFailureRefForOutput(ref string) string {
-	if matches := scenarioFailureRefPattern.FindStringSubmatch(ref); len(matches) == 3 {
+	exts := env.GaugeSpecFileExtensions()
+	escaped := make([]string, len(exts))
+	for i, ext := range exts {
+		escaped[i] = regexp.QuoteMeta(ext)
+	}
+	pattern := fmt.Sprintf(`(?i)^(.+(?:%s)):(\d+)`, strings.Join(escaped, "|"))
+	re := regexp.MustCompile(pattern)
+	if matches := re.FindStringSubmatch(ref); len(matches) == 3 {
 		return fmt.Sprintf("%s:%s", matches[1], matches[2])
 	}
 	return ref

--- a/execution/rerun/rerun.go
+++ b/execution/rerun/rerun.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sync"
 
 	"github.com/getgauge/common"
@@ -28,6 +29,8 @@ const (
 	failedFile         = "failures.json"
 	lastRunCmdFileName = "lastRunCmd.json"
 )
+
+var scenarioFailureRefPattern = regexp.MustCompile(`(?i)^(.+\.(?:spec|md)):(\d+)`)
 
 var failedMeta *failedMetadata
 
@@ -46,10 +49,16 @@ func (m *failedMetadata) args() []string {
 }
 
 func (m *failedMetadata) getFailedItems() []string {
+	seen := make(map[string]bool)
 	failedItems := []string{}
 	for _, v := range m.failedItemsMap {
 		for k := range v {
-			failedItems = append(failedItems, k)
+			outputRef := scenarioFailureRefForOutput(k)
+			if seen[outputRef] {
+				continue
+			}
+			seen[outputRef] = true
+			failedItems = append(failedItems, outputRef)
 		}
 	}
 	return failedItems
@@ -106,10 +115,28 @@ func ListenFailedScenarios(wg *sync.WaitGroup, specDirs []string) {
 	}()
 }
 
+func scenarioFailureRef(failedScenario string, sce *gauge.Scenario) string {
+	ref := fmt.Sprintf("%s:%d", failedScenario, sce.Span.Start)
+	if sce.SpecDataTableRow.IsInitialized() {
+		ref += fmt.Sprintf(":%d", sce.SpecDataTableRowIndex)
+	}
+	if sce.ScenarioDataTableRow.IsInitialized() {
+		ref += fmt.Sprintf(":%d", sce.ScenarioDataTableRowIndex)
+	}
+	return ref
+}
+
+func scenarioFailureRefForOutput(ref string) string {
+	if matches := scenarioFailureRefPattern.FindStringSubmatch(ref); len(matches) == 3 {
+		return fmt.Sprintf("%s:%s", matches[1], matches[2])
+	}
+	return ref
+}
+
 func prepareScenarioFailedMetadata(res *result.ScenarioResult, sce *gauge.Scenario, executionInfo *gauge_messages.ExecutionInfo) {
 	specPath := executionInfo.GetCurrentSpec().GetFileName()
 	failedScenario := util.RelPathToProjectRoot(specPath)
-	scenarioRef := fmt.Sprintf("%s:%v", failedScenario, sce.Span.Start)
+	scenarioRef := scenarioFailureRef(failedScenario, sce)
 	if res.GetFailed() {
 		failedMeta.addFailedItem(specPath, scenarioRef)
 		return

--- a/execution/rerun/rerun_test.go
+++ b/execution/rerun/rerun_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/getgauge/common"
 	"github.com/getgauge/gauge-proto/go/gauge_messages"
 	"github.com/getgauge/gauge/config"
-	"github.com/getgauge/gauge/env"
 	"github.com/getgauge/gauge/execution/result"
 	"github.com/getgauge/gauge/gauge"
 	"github.com/getgauge/gauge/util"
@@ -60,7 +59,7 @@ func (s *MySuite) TestGetScenarioFailedMetadata(c *C) {
 	prepareScenarioFailedMetadata(sr1, sce, &gauge_messages.ExecutionInfo{CurrentSpec: &gauge_messages.SpecInfo{FileName: spec1Abs}})
 
 	c.Assert(len(failedMeta.failedItemsMap[spec1Abs]), Equals, 1)
-	c.Assert(failedMeta.failedItemsMap[spec1Abs][spec1Rel+":2"], Equals, true)
+	c.Assert(failedMeta.failedItemsMap[spec1Abs][failureKey{filePath: spec1Rel, line: 2}], Equals, true)
 }
 
 func (s *MySuite) TestScenarioPassingOnRetryRemovesFailedMetadata(c *C) {
@@ -72,7 +71,7 @@ func (s *MySuite) TestScenarioPassingOnRetryRemovesFailedMetadata(c *C) {
 	passedResult := &result.ScenarioResult{ProtoScenario: &gauge_messages.ProtoScenario{ExecutionStatus: gauge_messages.ExecutionStatus_PASSED}}
 
 	prepareScenarioFailedMetadata(failedResult, sce, execInfo)
-	c.Assert(failedMeta.failedItemsMap[spec1Abs][spec1Rel+":2"], Equals, true)
+	c.Assert(failedMeta.failedItemsMap[spec1Abs][failureKey{filePath: spec1Rel, line: 2}], Equals, true)
 
 	prepareScenarioFailedMetadata(passedResult, sce, execInfo)
 	_, exists := failedMeta.failedItemsMap[spec1Abs]
@@ -98,10 +97,10 @@ func (s *MySuite) TestPassingTableRowDoesNotRemoveFailedTableRowMetadata(c *C) {
 	passedResult := &result.ScenarioResult{ProtoScenario: &gauge_messages.ProtoScenario{ExecutionStatus: gauge_messages.ExecutionStatus_PASSED}}
 
 	prepareScenarioFailedMetadata(failedResult, failedScenario, execInfo)
-	c.Assert(failedMeta.failedItemsMap[spec1Abs][spec1Rel+":13:2"], Equals, true)
+	c.Assert(failedMeta.failedItemsMap[spec1Abs][failureKey{filePath: spec1Rel, line: 13, hasSpecDataTableRow: true, specDataTableRow: 2}], Equals, true)
 
 	prepareScenarioFailedMetadata(passedResult, passedScenario, execInfo)
-	c.Assert(failedMeta.failedItemsMap[spec1Abs][spec1Rel+":13:2"], Equals, true)
+	c.Assert(failedMeta.failedItemsMap[spec1Abs][failureKey{filePath: spec1Rel, line: 13, hasSpecDataTableRow: true, specDataTableRow: 2}], Equals, true)
 }
 
 func (s *MySuite) TestScenarioFailureRefWithScenarioDataTableRow(c *C) {
@@ -112,9 +111,14 @@ func (s *MySuite) TestScenarioFailureRefWithScenarioDataTableRow(c *C) {
 		ScenarioDataTableRowIndex: 3,
 	}
 
-	ref := scenarioFailureRef("specs/example.spec", sce)
+	key := newScenarioFailureKey("specs/example.spec", sce)
 
-	c.Assert(ref, Equals, "specs/example.spec:5:0:3")
+	c.Assert(key.filePath, Equals, "specs/example.spec")
+	c.Assert(key.line, Equals, 5)
+	c.Assert(key.hasSpecDataTableRow, Equals, true)
+	c.Assert(key.specDataTableRow, Equals, 0)
+	c.Assert(key.hasScenarioDataTableRow, Equals, true)
+	c.Assert(key.scenarioDataTableRow, Equals, 3)
 }
 
 func (s *MySuite) TestScenarioFailureRefWithBothDataTableRows(c *C) {
@@ -128,9 +132,14 @@ func (s *MySuite) TestScenarioFailureRefWithBothDataTableRows(c *C) {
 		ScenarioDataTableRowIndex: 1,
 	}
 
-	ref := scenarioFailureRef("specs/example.spec", sce)
+	key := newScenarioFailureKey("specs/example.spec", sce)
 
-	c.Assert(ref, Equals, "specs/example.spec:5:2:1")
+	c.Assert(key.filePath, Equals, "specs/example.spec")
+	c.Assert(key.line, Equals, 5)
+	c.Assert(key.hasSpecDataTableRow, Equals, true)
+	c.Assert(key.specDataTableRow, Equals, 2)
+	c.Assert(key.hasScenarioDataTableRow, Equals, true)
+	c.Assert(key.scenarioDataTableRow, Equals, 1)
 }
 
 func (s *MySuite) TestSameTableRowPassingOnRetryRemovesFailedMetadata(c *C) {
@@ -147,7 +156,7 @@ func (s *MySuite) TestSameTableRowPassingOnRetryRemovesFailedMetadata(c *C) {
 	passedResult := &result.ScenarioResult{ProtoScenario: &gauge_messages.ProtoScenario{ExecutionStatus: gauge_messages.ExecutionStatus_PASSED}}
 
 	prepareScenarioFailedMetadata(failedResult, sce, execInfo)
-	c.Assert(failedMeta.failedItemsMap[spec1Abs][spec1Rel+":13:2"], Equals, true)
+	c.Assert(failedMeta.failedItemsMap[spec1Abs][failureKey{filePath: spec1Rel, line: 13, hasSpecDataTableRow: true, specDataTableRow: 2}], Equals, true)
 
 	prepareScenarioFailedMetadata(passedResult, sce, execInfo)
 	_, exists := failedMeta.failedItemsMap[spec1Abs]
@@ -157,9 +166,9 @@ func (s *MySuite) TestSameTableRowPassingOnRetryRemovesFailedMetadata(c *C) {
 func (s *MySuite) TestGetFailedItemsUsesFileLineForTableDrivenScenarios(c *C) {
 	spec1Rel := filepath.Join("specs", "example1.spec")
 	metaData := newFailedMetaData()
-	metaData.failedItemsMap[spec1Rel] = map[string]bool{
-		spec1Rel + ":13:2":   true,
-		spec1Rel + ":13:4:1": true,
+	metaData.failedItemsMap[spec1Rel] = map[failureKey]bool{
+		{filePath: spec1Rel, line: 13, hasSpecDataTableRow: true, specDataTableRow: 2}:                                                                    true,
+		{filePath: spec1Rel, line: 13, hasSpecDataTableRow: true, specDataTableRow: 4, hasScenarioDataTableRow: true, scenarioDataTableRow: 1}: true,
 	}
 
 	failedItems := metaData.getFailedItems()
@@ -183,20 +192,20 @@ func (s *MySuite) TestScenarioFailureRefDistinguishesSpecRowsForNestedTable(c *C
 		ScenarioDataTableRowIndex: 1,
 	}
 
-	ref0 := scenarioFailureRef("specs/example.spec", sce0)
-	ref1 := scenarioFailureRef("specs/example.spec", sce1)
+	key0 := newScenarioFailureKey("specs/example.spec", sce0)
+	key1 := newScenarioFailureKey("specs/example.spec", sce1)
 
-	c.Assert(ref0, Equals, "specs/example.spec:13:0:1")
-	c.Assert(ref1, Equals, "specs/example.spec:13:1:1")
-	c.Assert(ref0, Not(Equals), ref1)
+	c.Assert(key0, Not(Equals), key1)
+	c.Assert(key0.outputRef(), Equals, "specs/example.spec:13")
+	c.Assert(key1.outputRef(), Equals, "specs/example.spec:13")
 }
 
 func (s *MySuite) TestGetFailedItemsDeduplicatesNestedTableScenarios(c *C) {
 	spec1Rel := filepath.Join("specs", "example1.spec")
 	metaData := newFailedMetaData()
-	metaData.failedItemsMap[spec1Rel] = map[string]bool{
-		spec1Rel + ":13:0:1": true,
-		spec1Rel + ":13:1:1": true,
+	metaData.failedItemsMap[spec1Rel] = map[failureKey]bool{
+		{filePath: spec1Rel, line: 13, hasSpecDataTableRow: true, specDataTableRow: 0, hasScenarioDataTableRow: true, scenarioDataTableRow: 1}: true,
+		{filePath: spec1Rel, line: 13, hasSpecDataTableRow: true, specDataTableRow: 1, hasScenarioDataTableRow: true, scenarioDataTableRow: 1}: true,
 	}
 
 	failedItems := metaData.getFailedItems()
@@ -212,7 +221,7 @@ func (s *MySuite) TestAddSpecPreHookFailedMetadata(c *C) {
 	addFailedMetadata(spec1, []string{}, addSpecFailedMetadata)
 
 	c.Assert(len(failedMeta.failedItemsMap[spec1Rel]), Equals, 1)
-	c.Assert(failedMeta.failedItemsMap[spec1Rel][spec1Rel], Equals, true)
+	c.Assert(failedMeta.failedItemsMap[spec1Rel][failureKey{filePath: spec1Rel}], Equals, true)
 }
 
 func (s *MySuite) TestAddSpecPostHookFailedMetadata(c *C) {
@@ -223,21 +232,21 @@ func (s *MySuite) TestAddSpecPostHookFailedMetadata(c *C) {
 	addFailedMetadata(spec1, []string{}, addSpecFailedMetadata)
 
 	c.Assert(len(failedMeta.failedItemsMap[spec1Rel]), Equals, 1)
-	c.Assert(failedMeta.failedItemsMap[spec1Rel][spec1Rel], Equals, true)
+	c.Assert(failedMeta.failedItemsMap[spec1Rel][failureKey{filePath: spec1Rel}], Equals, true)
 }
 
 func (s *MySuite) TestAddSpecFailedMetadataOverwritesPreviouslyAddedValues(c *C) {
 	spec1Rel := filepath.Join("specs", "example1.spec")
 	spec1Abs := filepath.Join(config.ProjectRoot, spec1Rel)
 	spec1 := &result.SpecResult{ProtoSpec: &gauge_messages.ProtoSpec{PreHookFailures: []*gauge_messages.ProtoHookFailure{{ErrorMessage: "error"}}, FileName: spec1Abs}}
-	failedMeta.failedItemsMap[spec1Rel] = make(map[string]bool)
-	failedMeta.failedItemsMap[spec1Rel]["scn1"] = true
-	failedMeta.failedItemsMap[spec1Rel]["scn2"] = true
+	failedMeta.failedItemsMap[spec1Rel] = make(map[failureKey]bool)
+	failedMeta.failedItemsMap[spec1Rel][failureKey{filePath: spec1Rel, line: 1}] = true
+	failedMeta.failedItemsMap[spec1Rel][failureKey{filePath: spec1Rel, line: 2}] = true
 
 	addSpecFailedMetadata(spec1, []string{})
 
 	c.Assert(len(failedMeta.failedItemsMap[spec1Rel]), Equals, 1)
-	c.Assert(failedMeta.failedItemsMap[spec1Rel][spec1Rel], Equals, true)
+	c.Assert(failedMeta.failedItemsMap[spec1Rel][failureKey{filePath: spec1Rel}], Equals, true)
 }
 
 func (s *MySuite) TestGetRelativePath(c *C) {
@@ -250,14 +259,10 @@ func (s *MySuite) TestGetRelativePath(c *C) {
 }
 
 func (s *MySuite) TestGetFailedItemsWithCustomSpecExtension(c *C) {
-	old := env.GaugeSpecFileExtensions
-	env.GaugeSpecFileExtensions = func() []string { return []string{".foo"} }
-	defer func() { env.GaugeSpecFileExtensions = old }()
-
 	spec1Rel := filepath.Join("specs", "example1.foo")
 	metaData := newFailedMetaData()
-	metaData.failedItemsMap[spec1Rel] = map[string]bool{
-		spec1Rel + ":13:2": true,
+	metaData.failedItemsMap[spec1Rel] = map[failureKey]bool{
+		{filePath: spec1Rel, line: 13, hasSpecDataTableRow: true, specDataTableRow: 2}: true,
 	}
 
 	failedItems := metaData.getFailedItems()
@@ -269,11 +274,11 @@ func (s *MySuite) TestGetAllFailedItems(c *C) {
 	spec1Rel := filepath.Join("specs", "example1.spec")
 	spec2Rel := filepath.Join("specs", "example2.spec")
 	metaData := newFailedMetaData()
-	metaData.failedItemsMap[spec1Rel] = make(map[string]bool)
-	metaData.failedItemsMap[spec2Rel] = make(map[string]bool)
-	metaData.failedItemsMap[spec1Rel]["scn1"] = true
-	metaData.failedItemsMap[spec1Rel]["scn2"] = true
-	metaData.failedItemsMap[spec2Rel]["scn3"] = true
+	metaData.failedItemsMap[spec1Rel] = make(map[failureKey]bool)
+	metaData.failedItemsMap[spec2Rel] = make(map[failureKey]bool)
+	metaData.failedItemsMap[spec1Rel][failureKey{filePath: "scn1"}] = true
+	metaData.failedItemsMap[spec1Rel][failureKey{filePath: "scn2"}] = true
+	metaData.failedItemsMap[spec2Rel][failureKey{filePath: "scn3"}] = true
 
 	failedItems := metaData.getFailedItems()
 	sort.Strings(failedItems)

--- a/execution/rerun/rerun_test.go
+++ b/execution/rerun/rerun_test.go
@@ -78,6 +78,95 @@ func (s *MySuite) TestScenarioPassingOnRetryRemovesFailedMetadata(c *C) {
 	c.Assert(exists, Equals, false)
 }
 
+func (s *MySuite) TestPassingTableRowDoesNotRemoveFailedTableRowMetadata(c *C) {
+	spec1Rel := filepath.Join("specs", "example1.spec")
+	spec1Abs := filepath.Join(config.ProjectRoot, spec1Rel)
+	specTableRow := *gauge.NewTable([]string{"Word"}, [][]gauge.TableCell{{{Value: "Snap", CellType: gauge.Static}}}, 0)
+	execInfo := &gauge_messages.ExecutionInfo{CurrentSpec: &gauge_messages.SpecInfo{FileName: spec1Abs}}
+	failedScenario := &gauge.Scenario{
+		Span:                  &gauge.Span{Start: 13},
+		SpecDataTableRow:      specTableRow,
+		SpecDataTableRowIndex: 2,
+	}
+	passedScenario := &gauge.Scenario{
+		Span:                  &gauge.Span{Start: 13},
+		SpecDataTableRow:      specTableRow,
+		SpecDataTableRowIndex: 3,
+	}
+	failedResult := &result.ScenarioResult{ProtoScenario: &gauge_messages.ProtoScenario{ExecutionStatus: gauge_messages.ExecutionStatus_FAILED}}
+	passedResult := &result.ScenarioResult{ProtoScenario: &gauge_messages.ProtoScenario{ExecutionStatus: gauge_messages.ExecutionStatus_PASSED}}
+
+	prepareScenarioFailedMetadata(failedResult, failedScenario, execInfo)
+	c.Assert(failedMeta.failedItemsMap[spec1Abs][spec1Rel+":13:2"], Equals, true)
+
+	prepareScenarioFailedMetadata(passedResult, passedScenario, execInfo)
+	c.Assert(failedMeta.failedItemsMap[spec1Abs][spec1Rel+":13:2"], Equals, true)
+}
+
+func (s *MySuite) TestScenarioFailureRefWithScenarioDataTableRow(c *C) {
+	scenarioTableRow := *gauge.NewTable([]string{"Color"}, [][]gauge.TableCell{{{Value: "Red", CellType: gauge.Static}}}, 0)
+	sce := &gauge.Scenario{
+		Span:                      &gauge.Span{Start: 5},
+		ScenarioDataTableRow:      scenarioTableRow,
+		ScenarioDataTableRowIndex: 3,
+	}
+
+	ref := scenarioFailureRef("specs/example.spec", sce)
+
+	c.Assert(ref, Equals, "specs/example.spec:5:3")
+}
+
+func (s *MySuite) TestScenarioFailureRefWithBothDataTableRows(c *C) {
+	specTableRow := *gauge.NewTable([]string{"Word"}, [][]gauge.TableCell{{{Value: "Snap", CellType: gauge.Static}}}, 0)
+	scenarioTableRow := *gauge.NewTable([]string{"Color"}, [][]gauge.TableCell{{{Value: "Red", CellType: gauge.Static}}}, 0)
+	sce := &gauge.Scenario{
+		Span:                      &gauge.Span{Start: 5},
+		SpecDataTableRow:          specTableRow,
+		SpecDataTableRowIndex:     2,
+		ScenarioDataTableRow:      scenarioTableRow,
+		ScenarioDataTableRowIndex: 1,
+	}
+
+	ref := scenarioFailureRef("specs/example.spec", sce)
+
+	c.Assert(ref, Equals, "specs/example.spec:5:2:1")
+}
+
+func (s *MySuite) TestSameTableRowPassingOnRetryRemovesFailedMetadata(c *C) {
+	spec1Rel := filepath.Join("specs", "example1.spec")
+	spec1Abs := filepath.Join(config.ProjectRoot, spec1Rel)
+	specTableRow := *gauge.NewTable([]string{"Word"}, [][]gauge.TableCell{{{Value: "Snap", CellType: gauge.Static}}}, 0)
+	execInfo := &gauge_messages.ExecutionInfo{CurrentSpec: &gauge_messages.SpecInfo{FileName: spec1Abs}}
+	sce := &gauge.Scenario{
+		Span:                  &gauge.Span{Start: 13},
+		SpecDataTableRow:      specTableRow,
+		SpecDataTableRowIndex: 2,
+	}
+	failedResult := &result.ScenarioResult{ProtoScenario: &gauge_messages.ProtoScenario{ExecutionStatus: gauge_messages.ExecutionStatus_FAILED}}
+	passedResult := &result.ScenarioResult{ProtoScenario: &gauge_messages.ProtoScenario{ExecutionStatus: gauge_messages.ExecutionStatus_PASSED}}
+
+	prepareScenarioFailedMetadata(failedResult, sce, execInfo)
+	c.Assert(failedMeta.failedItemsMap[spec1Abs][spec1Rel+":13:2"], Equals, true)
+
+	prepareScenarioFailedMetadata(passedResult, sce, execInfo)
+	_, exists := failedMeta.failedItemsMap[spec1Abs]
+	c.Assert(exists, Equals, false)
+}
+
+func (s *MySuite) TestGetFailedItemsUsesFileLineForTableDrivenScenarios(c *C) {
+	spec1Rel := filepath.Join("specs", "example1.spec")
+	metaData := newFailedMetaData()
+	metaData.failedItemsMap[spec1Rel] = map[string]bool{
+		spec1Rel + ":13:2":   true,
+		spec1Rel + ":13:4:1": true,
+	}
+
+	failedItems := metaData.getFailedItems()
+	sort.Strings(failedItems)
+
+	c.Assert(failedItems, DeepEquals, []string{spec1Rel + ":13"})
+}
+
 func (s *MySuite) TestAddSpecPreHookFailedMetadata(c *C) {
 	spec1Rel := filepath.Join("specs", "example1.spec")
 	spec1Abs := filepath.Join(config.ProjectRoot, spec1Rel)

--- a/execution/rerun/rerun_test.go
+++ b/execution/rerun/rerun_test.go
@@ -85,11 +85,13 @@ func (s *MySuite) TestPassingTableRowDoesNotRemoveFailedTableRowMetadata(c *C) {
 	execInfo := &gauge_messages.ExecutionInfo{CurrentSpec: &gauge_messages.SpecInfo{FileName: spec1Abs}}
 	failedScenario := &gauge.Scenario{
 		Span:                  &gauge.Span{Start: 13},
+		HasSpecDataTable:      true,
 		SpecDataTableRow:      specTableRow,
 		SpecDataTableRowIndex: 2,
 	}
 	passedScenario := &gauge.Scenario{
 		Span:                  &gauge.Span{Start: 13},
+		HasSpecDataTable:      true,
 		SpecDataTableRow:      specTableRow,
 		SpecDataTableRowIndex: 3,
 	}
@@ -115,8 +117,7 @@ func (s *MySuite) TestScenarioFailureRefWithScenarioDataTableRow(c *C) {
 
 	c.Assert(key.filePath, Equals, "specs/example.spec")
 	c.Assert(key.line, Equals, 5)
-	c.Assert(key.hasSpecDataTableRow, Equals, true)
-	c.Assert(key.specDataTableRow, Equals, 0)
+	c.Assert(key.hasSpecDataTableRow, Equals, false)
 	c.Assert(key.hasScenarioDataTableRow, Equals, true)
 	c.Assert(key.scenarioDataTableRow, Equals, 3)
 }
@@ -126,6 +127,7 @@ func (s *MySuite) TestScenarioFailureRefWithBothDataTableRows(c *C) {
 	scenarioTableRow := *gauge.NewTable([]string{"Color"}, [][]gauge.TableCell{{{Value: "Red", CellType: gauge.Static}}}, 0)
 	sce := &gauge.Scenario{
 		Span:                      &gauge.Span{Start: 5},
+		HasSpecDataTable:          true,
 		SpecDataTableRow:          specTableRow,
 		SpecDataTableRowIndex:     2,
 		ScenarioDataTableRow:      scenarioTableRow,
@@ -149,6 +151,7 @@ func (s *MySuite) TestSameTableRowPassingOnRetryRemovesFailedMetadata(c *C) {
 	execInfo := &gauge_messages.ExecutionInfo{CurrentSpec: &gauge_messages.SpecInfo{FileName: spec1Abs}}
 	sce := &gauge.Scenario{
 		Span:                  &gauge.Span{Start: 13},
+		HasSpecDataTable:      true,
 		SpecDataTableRow:      specTableRow,
 		SpecDataTableRowIndex: 2,
 	}
@@ -181,12 +184,14 @@ func (s *MySuite) TestScenarioFailureRefDistinguishesSpecRowsForNestedTable(c *C
 	scenarioTableRow := *gauge.NewTable([]string{"Color"}, [][]gauge.TableCell{{{Value: "Red", CellType: gauge.Static}}}, 0)
 	sce0 := &gauge.Scenario{
 		Span:                      &gauge.Span{Start: 13},
+		HasSpecDataTable:          true,
 		SpecDataTableRowIndex:     0,
 		ScenarioDataTableRow:      scenarioTableRow,
 		ScenarioDataTableRowIndex: 1,
 	}
 	sce1 := &gauge.Scenario{
 		Span:                      &gauge.Span{Start: 13},
+		HasSpecDataTable:          true,
 		SpecDataTableRowIndex:     1,
 		ScenarioDataTableRow:      scenarioTableRow,
 		ScenarioDataTableRowIndex: 1,

--- a/execution/rerun/rerun_test.go
+++ b/execution/rerun/rerun_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getgauge/common"
 	"github.com/getgauge/gauge-proto/go/gauge_messages"
 	"github.com/getgauge/gauge/config"
+	"github.com/getgauge/gauge/env"
 	"github.com/getgauge/gauge/execution/result"
 	"github.com/getgauge/gauge/gauge"
 	"github.com/getgauge/gauge/util"
@@ -113,7 +114,7 @@ func (s *MySuite) TestScenarioFailureRefWithScenarioDataTableRow(c *C) {
 
 	ref := scenarioFailureRef("specs/example.spec", sce)
 
-	c.Assert(ref, Equals, "specs/example.spec:5:3")
+	c.Assert(ref, Equals, "specs/example.spec:5:0:3")
 }
 
 func (s *MySuite) TestScenarioFailureRefWithBothDataTableRows(c *C) {
@@ -167,6 +168,42 @@ func (s *MySuite) TestGetFailedItemsUsesFileLineForTableDrivenScenarios(c *C) {
 	c.Assert(failedItems, DeepEquals, []string{spec1Rel + ":13"})
 }
 
+func (s *MySuite) TestScenarioFailureRefDistinguishesSpecRowsForNestedTable(c *C) {
+	scenarioTableRow := *gauge.NewTable([]string{"Color"}, [][]gauge.TableCell{{{Value: "Red", CellType: gauge.Static}}}, 0)
+	sce0 := &gauge.Scenario{
+		Span:                      &gauge.Span{Start: 13},
+		SpecDataTableRowIndex:     0,
+		ScenarioDataTableRow:      scenarioTableRow,
+		ScenarioDataTableRowIndex: 1,
+	}
+	sce1 := &gauge.Scenario{
+		Span:                      &gauge.Span{Start: 13},
+		SpecDataTableRowIndex:     1,
+		ScenarioDataTableRow:      scenarioTableRow,
+		ScenarioDataTableRowIndex: 1,
+	}
+
+	ref0 := scenarioFailureRef("specs/example.spec", sce0)
+	ref1 := scenarioFailureRef("specs/example.spec", sce1)
+
+	c.Assert(ref0, Equals, "specs/example.spec:13:0:1")
+	c.Assert(ref1, Equals, "specs/example.spec:13:1:1")
+	c.Assert(ref0, Not(Equals), ref1)
+}
+
+func (s *MySuite) TestGetFailedItemsDeduplicatesNestedTableScenarios(c *C) {
+	spec1Rel := filepath.Join("specs", "example1.spec")
+	metaData := newFailedMetaData()
+	metaData.failedItemsMap[spec1Rel] = map[string]bool{
+		spec1Rel + ":13:0:1": true,
+		spec1Rel + ":13:1:1": true,
+	}
+
+	failedItems := metaData.getFailedItems()
+
+	c.Assert(failedItems, DeepEquals, []string{spec1Rel + ":13"})
+}
+
 func (s *MySuite) TestAddSpecPreHookFailedMetadata(c *C) {
 	spec1Rel := filepath.Join("specs", "example1.spec")
 	spec1Abs := filepath.Join(config.ProjectRoot, spec1Rel)
@@ -210,6 +247,22 @@ func (s *MySuite) TestGetRelativePath(c *C) {
 	path := util.RelPathToProjectRoot(spec1Abs)
 
 	c.Assert(path, Equals, spec1Rel)
+}
+
+func (s *MySuite) TestGetFailedItemsWithCustomSpecExtension(c *C) {
+	old := env.GaugeSpecFileExtensions
+	env.GaugeSpecFileExtensions = func() []string { return []string{".foo"} }
+	defer func() { env.GaugeSpecFileExtensions = old }()
+
+	spec1Rel := filepath.Join("specs", "example1.foo")
+	metaData := newFailedMetaData()
+	metaData.failedItemsMap[spec1Rel] = map[string]bool{
+		spec1Rel + ":13:2": true,
+	}
+
+	failedItems := metaData.getFailedItems()
+
+	c.Assert(failedItems, DeepEquals, []string{spec1Rel + ":13"})
 }
 
 func (s *MySuite) TestGetAllFailedItems(c *C) {

--- a/gauge/scenario.go
+++ b/gauge/scenario.go
@@ -19,6 +19,7 @@ type Scenario struct {
 	DataTable                 DataTable
 	SpecDataTableRow          Table
 	SpecDataTableRowIndex     int
+	HasSpecDataTable          bool
 	ScenarioDataTableRow      Table
 	ScenarioDataTableRowIndex int
 	Span                      *Span

--- a/parser/dataTableSpecs.go
+++ b/parser/dataTableSpecs.go
@@ -84,9 +84,11 @@ func copyScenarios(scenarios []*gauge.Scenario, table gauge.Table, i int, errMap
 			Comments: scn.Comments,
 			Span:     scn.Span,
 		}
+		if table.IsInitialized() {
+			newScn.SpecDataTableRowIndex = i
+		}
 		if assignSpecTable {
 			newScn.SpecDataTableRow = table
-			newScn.SpecDataTableRowIndex = i
 		}
 		if scnTableRow.IsInitialized() {
 			newScn.ScenarioDataTableRow = scnTableRow

--- a/parser/dataTableSpecs.go
+++ b/parser/dataTableSpecs.go
@@ -85,6 +85,7 @@ func copyScenarios(scenarios []*gauge.Scenario, table gauge.Table, i int, errMap
 			Span:     scn.Span,
 		}
 		if table.IsInitialized() {
+			newScn.HasSpecDataTable = true
 			newScn.SpecDataTableRowIndex = i
 		}
 		if assignSpecTable {

--- a/parser/dataTableSpecs_test.go
+++ b/parser/dataTableSpecs_test.go
@@ -207,11 +207,21 @@ func TestGetSpecsForDataTableRowsWithMixedScenarios(t *testing.T) {
 			if scn.SpecDataTableRow.IsInitialized() {
 				t.Errorf("Scenario with own table should not have spec table row when it doesn't use spec params")
 			}
+			if scn.SpecDataTableRowIndex != 0 {
+				t.Errorf("Scenario with own table should have SpecDataTableRowIndex=0 for first spec row, got %d", scn.SpecDataTableRowIndex)
+			}
 		}
 	}
 
 	if scenarioWithOwnTableCount != 2 {
 		t.Errorf("Expected 2 iterations of scenario with own table in first spec, got %d", scenarioWithOwnTableCount)
+	}
+
+	// Verify second spec's scenario also gets the correct SpecDataTableRowIndex
+	for _, scn := range secondSpec.Scenarios {
+		if scn.SpecDataTableRowIndex != 1 {
+			t.Errorf("Scenario in second spec should have SpecDataTableRowIndex=1, got %d", scn.SpecDataTableRowIndex)
+		}
 	}
 }
 

--- a/parser/dataTableSpecs_test.go
+++ b/parser/dataTableSpecs_test.go
@@ -261,7 +261,7 @@ func TestCreateSpecsForTableRows(t *testing.T) {
 			Heading: &gauge.Heading{},
 			Scenarios: []*gauge.Scenario{{Steps: []*gauge.Step{{Args: []*gauge.StepArg{{Value: "header", ArgType: gauge.Dynamic, Name: "header"}}}}, SpecDataTableRow: *gauge.NewTable([]string{"header"}, [][]gauge.TableCell{
 				{{Value: "row1", CellType: gauge.Static}},
-			}, 0), SpecDataTableRowIndex: 0}},
+			}, 0), HasSpecDataTable: true, SpecDataTableRowIndex: 0}},
 			DataTable: gauge.DataTable{Table: gauge.NewTable([]string{"header"}, [][]gauge.TableCell{
 				{{Value: "row1", CellType: gauge.Static}},
 			}, 0)},
@@ -272,7 +272,7 @@ func TestCreateSpecsForTableRows(t *testing.T) {
 				}, 0)},
 				&gauge.Scenario{Steps: []*gauge.Step{{Args: []*gauge.StepArg{{Value: "header", ArgType: gauge.Dynamic, Name: "header"}}}}, SpecDataTableRow: *gauge.NewTable([]string{"header"}, [][]gauge.TableCell{
 					{{Value: "row1", CellType: gauge.Static}},
-				}, 0), SpecDataTableRowIndex: 0},
+				}, 0), HasSpecDataTable: true, SpecDataTableRowIndex: 0},
 			},
 			TearDownSteps: []*gauge.Step{{Args: []*gauge.StepArg{{Value: "abc", ArgType: gauge.Static}}}},
 		},
@@ -280,7 +280,7 @@ func TestCreateSpecsForTableRows(t *testing.T) {
 			Heading: &gauge.Heading{},
 			Scenarios: []*gauge.Scenario{{Steps: []*gauge.Step{{Args: []*gauge.StepArg{{Value: "header", ArgType: gauge.Dynamic, Name: "header"}}}}, SpecDataTableRow: *gauge.NewTable([]string{"header"}, [][]gauge.TableCell{
 				{{Value: "row2", CellType: gauge.Static}},
-			}, 0), SpecDataTableRowIndex: 1}},
+			}, 0), HasSpecDataTable: true, SpecDataTableRowIndex: 1}},
 			DataTable: gauge.DataTable{Table: gauge.NewTable([]string{"header"}, [][]gauge.TableCell{
 				{{Value: "row2", CellType: gauge.Static}},
 			}, 0)},
@@ -291,7 +291,7 @@ func TestCreateSpecsForTableRows(t *testing.T) {
 				}, 0)},
 				&gauge.Scenario{Steps: []*gauge.Step{{Args: []*gauge.StepArg{{Value: "header", ArgType: gauge.Dynamic, Name: "header"}}}}, SpecDataTableRow: *gauge.NewTable([]string{"header"}, [][]gauge.TableCell{
 					{{Value: "row2", CellType: gauge.Static}},
-				}, 0), SpecDataTableRowIndex: 1},
+				}, 0), HasSpecDataTable: true, SpecDataTableRowIndex: 1},
 			},
 			TearDownSteps: []*gauge.Step{{Args: []*gauge.StepArg{{Value: "abc", ArgType: gauge.Static}}}},
 		},


### PR DESCRIPTION
Proposed fix for issue: https://github.com/getgauge/gauge/issues/2871

# Problem

With a data-table-driven scenario, Gauge emits a separate ScenarioEnd event for each table row, but they all share the same file:line key because they're the same scenario definition. So with a 3-row table where row 1 passes, row 2 fails, row 3 passes:                                                                                                                                                              
                                                                                                                                                                                                              
  1. Row 1 passes -> removeFailedItem("example.spec:13") -> no-op (nothing stored yet)                                                                                                                          
  2. Row 2 fails -> addFailedItem("example.spec:13") -> failure recorded
  3. Row 3 passes -> removeFailedItem("example.spec:13") -> incorrectly removes row 2's failure

Result: failures.json has no entry despite the scenario genuinely failing for row 2. Rerunning failed tests does nothing.

# Fix

Two-step approach:

  1. Internal tracking uses precise keys. scenarioFailureRef now builds keys that include table row indices (e.g., example.spec:13:2 for spec-level table row index 2. This means row 3 passing calls removeFailedItem("example.spec:13:3"), which doesn't match row 2's key example.spec:13:2, so the failure is preserved.

  2. Output strips back to file:line format. scenarioFailureRefForOutput reduces example.spec:13:2 back to example.spec:13 when building FailedItems for failures.json, because Gauge's parser expects the file:line format. Deduplication ensures multiple failed rows produce a single entry.

Note, nested spec and scenario tables are supported resulting in internal keys like example.spec:13:2:1

# Tests

I've added a number of tests for regression.